### PR TITLE
Allow an empty date field to be valid when the answer is not required

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 AssemblyLine
+Copyright (c) 2022 AssemblyLine
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -9,6 +9,7 @@ js_text = """\
       var required = $(dateElement).closest('.da-form-group').hasClass('darequired');
       $(dateElement).hide();
       $(dateElement).attr('type', 'hidden');
+      $(dateElement).attr('aria-hidden', 'true');
       
       //Construct the input components
       var parentElement = $('<div class="form-row row">');
@@ -106,13 +107,12 @@ js_text = """\
     });
   });
   
-  // No jQuery validation, which doesn't work on hidden elements
+  // No jQuery validation, since it doesn't work on hidden elements
 """
 
 class ThreePartsDate(CustomDataType):
   name = 'ThreePartsDate'
   input_type = 'ThreePartsDate'
-  #input_class = 'da-ThreePartsDate'
   javascript = js_text
   jq_message = word('Answer with a valid date')
   is_object = True
@@ -147,7 +147,6 @@ class ThreePartsDate(CustomDataType):
 class BirthDate(ThreePartsDate):
   name = 'BirthDate'
   input_type = 'BirthDate'
-  #input_class = 'da-BirthDate'
   javascript = js_text.replace("ThreePartsDate", "BirthDate")
   jq_message = word('Answer with a valid date of birth')
   is_object = True

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -1,26 +1,37 @@
-from docassemble.base.util import CustomDataType, DAValidationError, word, as_datetime, today
+from docassemble.base.util import CustomDataType, DAValidationError, word, as_datetime, today, date_difference, log
+import re
 
 js_text = """\
   //this is an adaptation of Jonathan Pyle's datereplace.js
   $(document).on('daPageLoad', function(){
     $('input[type="ThreePartsDate"]').each(function(){
-  	  var dateElement = this;
-  	  $(dateElement).hide();
-  	  $(dateElement).attr('type', 'hidden');
+      var dateElement = this;
+      var required = $(dateElement).closest('.da-form-group').hasClass('darequired');
+      $(dateElement).hide();
+      $(dateElement).attr('type', 'hidden');
       
       //Construct the input components
-  	  var parentElement = $('<div class="form-row row">');	  
-  	  var monthParent = $('<div class="col">');
-      var monthLabel = $('<div style="text-align:center">Month</div>');	    
-      var monthElement = $('<select class="form-control" style="width:7.5em" required>');
-  	  var dayParent = $('<div class="col">');    
+      var parentElement = $('<div class="form-row row">');
+      
+      var monthParent = $('<div class="col">');
+      var monthLabel = $('<div style="text-align:center">Month</div>');     
+      var monthElement = $('<select class="form-control" style="width:7.5em">');
+      monthElement.attr( 'required', required );
+      monthElement.prop( 'required', required );
+      
+      var dayParent = $('<div class="col">');    
       var dayLabel = $('<div style="text-align:center">Day</div>');    
-      var dayElement = $('<input type="text" class="form-control" type="number" min="1" max="31"  required>' );  
-      var yearParent = $('<div class="col">');	  
+      var dayElement = $('<input type="text" class="form-control" type="number" min="1" max="31">' );
+      dayElement.attr( 'required', required );
+      dayElement.prop( 'required', required );
+      
+      var yearParent = $('<div class="col">');    
       var yearLabel = $('<div style="text-align:center">Year</div>');
       //Do not restrict year input range for now. 
-      var yearElement = $('<input type="text" class="form-control" type="number" required>');
-  	    
+      var yearElement = $('<input type="text" class="form-control" type="number">');
+      yearElement.attr( 'required', required );
+      yearElement.prop( 'required', required );
+        
       // If we're returning to a variable that has already been defined
       // prepare to use that variable's values
       var dateParts;
@@ -33,109 +44,131 @@ js_text = """\
         dateParts = null;
       }
           
-      // Create contents of visible input fields	  
-      // "No month selected" option
-  	  var opt = $("<option>");
-  	  opt.val("");
-  	  opt.text("    ");
-  	  monthElement.append(opt);
-      // Add every calendar month (based on user's computer's date system? lanugage?)
-  	  for(var month=0; month < 12; month++){
-  	      opt = $("<option>");
-  	      if (month < 9){
-  	  	opt.val('0' + (month + 1));
-  	      }
-  	      else{
-  	  	opt.val(month + 1);
-  	      }
-  	      var dt = new Date(1970, month, 1);
-  	      opt.text(dt.toLocaleString('default', { month: 'long' }));
-          // Use previous values if possible
-          if ( dateParts && parseInt( opt.val()) == dateParts[ 0 ]) {
-            opt.attr('selected', 'selected');
-          }
-  	      monthElement.append(opt);
-  	  }
-    
-      // Use previous values if possible
-  	  if ( dateParts ) {		
-  	  	dayElement.val( dateParts[ 1 ]);
-  	  	yearElement.val( dateParts[ 2 ]);
-  	  }
+      // Insert previous answers if possible
       
-      //Update original element
-  	  function updateDate(){
-  	  	$(dateElement).val($(monthElement).val() + '/' + $(dayElement).val() + '/' + $(yearElement).val());	
-  	  }	
-  	  
-  	  $(dateElement).before(parentElement);	
-  	  $(monthParent).append(monthLabel);
-  	  $(monthParent).append(monthElement);
-  	  $(parentElement).append(monthParent);	
-  	  $(dayParent).append(dayLabel);
-  	  $(dayParent).append(dayElement);
-  	  $(parentElement).append(dayParent);	
-  	  $(yearParent).append(yearLabel);
-  	  $(yearParent).append(yearElement);
-  	  $(parentElement).append(yearParent);
-  	  
-  	  yearElement.on('change', updateDate);
-  	  monthElement.on('change', updateDate);
-  	  dayElement.on('change', updateDate);	
-  	  updateDate();
+      // -- Month --
+      // "No month selected" option
+      var first_opt = $("<option>");
+      first_opt.val("");
+      first_opt.text("");
+      monthElement.append( first_opt );
+      // Add every calendar month (based on user's computer's date system? lanugage?)
+      var option = null
+      for(var month=0; month < 12; month++){
+        opt = $("<option>");
+        if ( month < 9 ){
+          opt.val('0' + (month + 1));
+        } else {
+          opt.val(month + 1);
+        }
+        
+        // Convert the month number to a month name for the option text
+        var dt = new Date(1970, month, 1);
+        opt.text(dt.toLocaleString('default', { month: 'long' }));
+        
+        // Use previous values if possible
+        if ( dateParts && parseInt( opt.val() ) === dateParts[ 0 ]) {
+          opt.attr('selected', 'selected');
+        }
+        
+        monthElement.append(opt);
+      }  // ends for every month
+    
+      // -- Day and year --
+      // Use previous values if possible
+      if ( dateParts ) {    
+        dayElement.val( dateParts[ 1 ]);
+        yearElement.val( dateParts[ 2 ]);
+      }
+      
+      // Update value of original input when changes values.
+      function updateDate(){
+        var val = $(monthElement).val() + '/' + $(dayElement).val() + '/' + $(yearElement).val();
+        if ( val === '//' ) { val = ''; }
+        $( dateElement ).val( val );
+      };  // Ends updateDate()
+      
+      $(dateElement).before(parentElement); 
+      $(monthParent).append(monthLabel);
+      $(monthParent).append(monthElement);
+      $(parentElement).append(monthParent); 
+      $(dayParent).append(dayLabel);
+      $(dayParent).append(dayElement);
+      $(parentElement).append(dayParent); 
+      $(yearParent).append(yearLabel);
+      $(yearParent).append(yearElement);
+      $(parentElement).append(yearParent);
+      
+      // Updates will be triggered when the user leave an input field
+      yearElement.on('change', updateDate);
+      monthElement.on('change', updateDate);
+      dayElement.on('change', updateDate);
     });
-  });  
-  $.validator.addMethod('ThreePartsDate', function(value, element, params){
-    //Placeholder. Will add client side validation here down the road.
-    return /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(value);  
   });
+  
+  // No jQuery validation, which doesn't work on hidden elements
 """
 
 class ThreePartsDate(CustomDataType):
-  container_class = 'da-ThreePartsDate-container'
   name = 'ThreePartsDate'
   input_type = 'ThreePartsDate'
-  input_class = 'da-ThreePartsDate'
-  is_object = True
+  #input_class = 'da-ThreePartsDate'
   javascript = js_text
-  jq_rule = 'ThreePartsDate'
-  jq_message = 'Your input does not look right.'
+  jq_message = word('Answer with a valid date')
+  is_object = True
+  # Probably won't work because the input to validate is hidden
+  jq_rule = 'date'
+  
   @classmethod
   def validate(cls, item):
-	  # Change input string into DADateTime		
-    try:
-      mydate = as_datetime( item )    
-      return True		
-    except:
-      msg =  item + " is not a valid date."      
-      raise DAValidationError(msg)
+    # If there's no input in the item, it's valid
+    if not isinstance(item, str) or item == '':
+      return True
+    else:
+      # Otherwise it needs to be a date after the year 1000. We ourselves make
+      # sure this format is created if the user gives valid info.
+      matches_date_pattern = re.search( r'^\d{1,2}\/\d{1,2}\/\d{4}$', item )
+      if matches_date_pattern:
+        return True
+      else:
+        raise DAValidationError(f"{ item } {word('is not a valid date')}")
   
   @classmethod
   def transform(cls, item):
-    return as_datetime(item)
+    if item:
+      return as_datetime(item)
   
   @classmethod
   def default_for(cls, item):
-    return item.format("MM/dd/yyyy")
-  
+    if item:
+      return item.format("MM/dd/yyyy")
+
+
 class BirthDate(ThreePartsDate):
   name = 'BirthDate'
   input_type = 'BirthDate'
-  input_class = 'da-BirthDate'
+  #input_class = 'da-BirthDate'
+  javascript = js_text.replace("ThreePartsDate", "BirthDate")
+  jq_message = word('Answer with a valid date of birth')
   is_object = True
-  jq_rule = 'BirthDate'
-  
-  javascript = js_text.replace("ThreePartsDate","BirthDate")
+  # Probably won't work because the input to validate is hidden
+  jq_rule = 'date'
   
   @classmethod
   def validate(cls, item):
-	  # Change input string into DADateTime		
-    try:
-      mydate = as_datetime( item )      
-    except:
-      msg =  item + " is not a valid date."      
-      raise DAValidationError(msg)    
-    if mydate <= today():
+    # If there's no input in the item, it's valid
+    if not isinstance(item, str) or item == '':
       return True
     else:
-      raise DAValidationError("Please enter a date before today")
+      # Otherwise it needs to be a date on or before today and after the year 1000.
+      # We ourselves create this format if the user gives valid info.
+      matches_date_pattern = re.search( r'^\d{1,2}\/\d{1,2}\/\d{4}$', item )
+      if matches_date_pattern:
+        date_diff = date_difference(starting=as_datetime( item ), ending=today())
+        if date_diff.days >= 0.0:
+          return True
+        else:
+          raise DAValidationError(word("Answer with a <strong>date of birth</strong>"))
+      else:
+        msg = f"{ item } {word('is not a valid <strong>date of birth</strong>')}"
+        raise DAValidationError(msg)

--- a/docassemble/ALToolbox/data/questions/ThreePartsDate.yml
+++ b/docassemble/ALToolbox/data/questions/ThreePartsDate.yml
@@ -4,6 +4,11 @@ metadata:
 modules:
   - .ThreePartsDate
 ---
+mandatory: True
+code: |
+  date_of_birth
+  end
+---
 question: |
   Regular datatype vs ThreePartsDate datatype.
 subquestion: | 
@@ -15,16 +20,42 @@ subquestion: |
 
 fields:
   - When is your high school graduation?: date_of_graduation
-    datatype: ThreePartsDate  
-    default: '2/1/2000'
-  - When did you start working: employment_date
-    datatype: date
+    datatype: ThreePartsDate
     required: False
-  - Validated birth: date_of_birth
+  - Birth date (today is valid): date_of_birth
     datatype: BirthDate
+    default: ${ today(format='MM/dd/yyyy') }
+    required: True
+  - Show hidden date fields: show_fields
+    datatype: yesno
+  - Court date: court_date
+    datatype: ThreePartsDate
+    default: '2/1/2055'
+    required: True
+    show if: show_fields
+  - Date you lost your first tooth: tooth_date
+    datatype: BirthDate
+    required: False
+    show if: show_fields
 ---
-mandatory: true
+#mandatory: true
+event: end
 question: |
-  You were born on ${ date_of_birth }.  
+  Your dates
+subquestion: |
 
+  % if date_of_birth:
+  You were born ${ date_of_birth }.
+  % endif
+
+  % if date_of_graduation:
   Your graduation date is ${ date_of_graduation }
+  % endif
+
+  % if defined('court_date'):
+  Your court date is ${ court_date }
+  % endif
+
+  % if defined('tooth_date') and not tooth_date is None:
+  The date lost your first tooth was ${ tooth_date }
+  % endif


### PR DESCRIPTION
Closes #44.

Sorry that GitHub is doing such a bad job of showing when changes are just whitespace changes. It was just easier for me to read with some indentation tweaks.

I would appreciate some testing on this. To test this, you'll have to edit the files and change the customdatatype names in the .py and the .yml because they could otherwise be overridden by our current customdatatypes. For me, they were overridden. I dealt with it by adding "Foo" before the names.