### PR TITLE
Correct `aria-controls` to refernce correct id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+docassemble.ALToolbox.egg-info/**

--- a/docassemble/ALToolbox/misc.py
+++ b/docassemble/ALToolbox/misc.py
@@ -135,17 +135,17 @@ def tabbed_templates_html(tab_group_name: str, *pargs) -> str:
     tabs = f'<ul class="nav nav-tabs" id="{tab_group_name}" role="tablist">\n'
     tab_content = '<div class="tab-content" id="myTabContent">'
     for index, templ in enumerate(pargs):
-        tab_id = space_to_underscore(str(templ.subject))
+        tab_id = f"{tab_group_name}-{space_to_underscore(str(templ.subject))}"
         tabs += '<li class="nav-item" role="presentation">\n'
         if index == 0:
-            tabs += f'<a class="nav-link active" id="{tab_group_name}-{tab_id}-tab" data-bs-toggle="tab" href="#{tab_group_name}-{tab_id}" role="tab" aria-controls="{tab_id}" aria-selected="true">{templ.subject}</a>\n'
-            tab_content += f'<div class="tab-pane fade show active" id="{tab_group_name}-{tab_id}" role="tabpanel" aria-labelledby="{tab_group_name}-{tab_id}-tab">\n'
+            tabs += f'<a class="nav-link active" id="{tab_id}-tab" data-bs-toggle="tab" href="#{tab_id}" role="tab" aria-controls="{tab_id}" aria-selected="true">{templ.subject}</a>\n'
+            tab_content += f'<div class="tab-pane fade show active" id="{tab_id}" role="tabpanel" aria-labelledby="{tab_id}-tab">\n'
             tab_content += templ.content_as_html()
 
             tab_content += "\n</div>\n"
         else:
-            tabs += f'<a class="nav-link" id="{tab_group_name}-{tab_id}-tab" data-bs-toggle="tab" href="#{tab_group_name}-{tab_id}" role="tab" aria-controls="{tab_id}" aria-selected="false">{templ.subject}</a>\n'
-            tab_content += f'<div class="tab-pane fade" id="{tab_group_name}-{tab_id}" role="tabpanel" aria-labelledby="{tab_group_name}-{tab_id}-tab">\n'
+            tabs += f'<a class="nav-link" id="{tab_id}-tab" data-bs-toggle="tab" href="#{tab_id}" role="tab" aria-controls="{tab_id}" aria-selected="false">{templ.subject}</a>\n'
+            tab_content += f'<div class="tab-pane fade" id="{tab_id}" role="tabpanel" aria-labelledby="{tab_id}-tab">\n'
             tab_content += templ.content_as_html()
             tab_content += "\n</div>\n"
         tabs += "</li>"


### PR DESCRIPTION
Issue was caught by aXe-core testing: https://dequeuniversity.com/rules/axe/4.4/aria-valid-attr-value?application=axe-puppeteer

The issue happened because `tag_group_name` was added to the beginning of each id / href, but not to aria-controls.
The `tab_id` was never used individually, so I just updated it to include both `tab_group_name` and `tab_id`,
and then replaced its used in the tabs and tab panels.