### PR TITLE
Return empty str if template is blank

### DIFF
--- a/docassemble/ALToolbox/misc.py
+++ b/docassemble/ALToolbox/misc.py
@@ -107,6 +107,8 @@ def collapse_template(template, classname=None):
     """
     Insert HTML for a Bootstrap "collapse" div.
     """
+    if not template.subject_as_html(trim=True) and not template.content_as_html():
+        return ""
     if classname is None:
         classname = " bg-light"
     else:


### PR DESCRIPTION
Ran into this when I tried to have the contents of a collapse-able template vary on some other variables in the interview (only showing IL specific information to fill in a case number when the jurisdiction was IL). IMO returning an empty string instead of a drop down with nothing in the title or body is probably better.