### PR TITLE
Business day normalize date strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+.vscode/
 docassemble.ALToolbox.egg-info/**

--- a/docassemble/ALToolbox/business_days.py
+++ b/docassemble/ALToolbox/business_days.py
@@ -15,22 +15,24 @@ from typing import Union, Dict
 
 def standard_holidays(
     year, country="US", subdiv="MA", add_holidays=None, remove_holidays=None
-) -> Dict[str, str]:
+) -> holidays.HolidayBase:
     """
     Get all holidays in the specified year, country, and state (or other subdivision).
     Note that this draws on the "holidays" package which may deviate slightly from
     holidays observed by a local court, but should be very close to accurate.
 
-    Returns a dictionary like:
+    Returns a dictionary like-object that you can treat like:
     {
         "2021-01-01": "New Year's Day",
         ...
         "2021-12-25": "Christmas Day",
     }
+    
+    In place of a string, the object that is returned can also be treated as though
+    the keys are datetime.date objects.
     """
     # 1. Get standard holidays from python's holidays module
-    countr_holidays = []
-    countr_holidays = holidays.country_holidays(
+    countr_holidays:holidays.HolidayBase = holidays.country_holidays(
         country=country, subdiv=subdiv, years=year
     )
 

--- a/docassemble/ALToolbox/business_days.py
+++ b/docassemble/ALToolbox/business_days.py
@@ -13,8 +13,6 @@ from typing import Union
 """
 
 
-
-
 def standard_holidays(
     year, country="US", subdiv="MA", add_holidays=None, remove_holidays=None
 ) -> dict:
@@ -123,18 +121,32 @@ def non_business_days(
 
 
 def is_business_day(
-    date:Union[str, DADateTime], country="US", subdiv="MA", add_holidays=None, remove_holidays=None
+    date: Union[str, DADateTime],
+    country="US",
+    subdiv="MA",
+    add_holidays=None,
+    remove_holidays=None,
 ) -> bool:
     if not isinstance(date, DADateTime):
         date = as_datetime(date)
-    if date.dow in [6,7]: # Docassemble codes Saturday and Sunday as 6 and 7 respectively
+    if date.dow in [
+        6,
+        7,
+    ]:  # Docassemble codes Saturday and Sunday as 6 and 7 respectively
         return False
-    if date.format("yyyy-MM-dd") in standard_holidays(year=date.year, country=country, subdiv=subdiv, add_holidays=add_holidays, remove_holidays=remove_holidays):
+    if date.format("yyyy-MM-dd") in standard_holidays(
+        year=date.year,
+        country=country,
+        subdiv=subdiv,
+        add_holidays=add_holidays,
+        remove_holidays=remove_holidays,
+    ):
         return False
     return True
 
+
 def get_next_business_day(
-    start_date:Union[str, DADateTime],
+    start_date: Union[str, DADateTime],
     wait_n_days=1,
     country="US",
     subdiv="MA",
@@ -149,6 +161,12 @@ def get_next_business_day(
         start_date = as_datetime(start_date)
     date_to_check = start_date.plus(days=wait_n_days)
 
-    while not is_business_day(date_to_check, country=country, subdiv=subdiv, add_holidays=add_holidays, remove_holidays=remove_holidays):
+    while not is_business_day(
+        date_to_check,
+        country=country,
+        subdiv=subdiv,
+        add_holidays=add_holidays,
+        remove_holidays=remove_holidays,
+    ):
         date_to_check = date_to_check.plus(days=1)
     return date_to_check

--- a/docassemble/ALToolbox/test_altoolbox.py
+++ b/docassemble/ALToolbox/test_altoolbox.py
@@ -1,0 +1,10 @@
+import unittest
+from .business_days import is_business_day, get_next_business_day
+from docassemble.base.util import today
+
+class TestBusinessDays(unittest.TestCase):
+    def test_is_business_day(self):
+        self.assertFalse(is_business_day("2022-0-05"))
+        self.assertTrue(is_business_day("2022-09-06"))
+        this_years_christmas = today().replace(month=12, day=25)
+        self.assertFalse(is_business_day(this_years_christmas))


### PR DESCRIPTION
The existing code didn't seem to work with DADateTime objects because it was expecting dates formatted like `%m/%d/%Y`. Switched to using ISO date formats throughout and simplified the logic a bit. I'm not sure if the `non_business_days()` function is strictly needed but I left that basically alone for now as it's not necessary to the core functionality.

A simple test YAML to explore:

```yaml
modules:
  - .business_days
---
question: |
  What date do you want to check?
fields:
  - Date: the_date
    datatype: date
---
mandatory: True
question: |
  % if is_business_day(the_date):
  ${ the_date } is a business day
  % else:
  ${ the_date } is NOT a business day
  
  The next business day is ${ get_next_business_day(the_date) }
  % endif
```  

@purplesky2016 feel free to ignore but figured this was your baby and I realized I don't know when your summer break is over!