### PR TITLE
Fixed bugs in ALIncome:

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,7 @@ jobs:
       - name: locales
         run: |
             sudo locale-gen en_US.UTF-8
+            # TODO(#104): run the tests while set to a different locale
             sudo update-locale LANG=en_US.UTF-8
       - name: Check
         uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,14 +4,21 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  LANG: "en_US.UTF-8"
+
 jobs:
-  test-assemblyline:
+  test-altoolbox:
     runs-on: ubuntu-latest
     name: Run python only unit tests
     env:
       ISUNITTEST: true
     steps:
       - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
+      - name: locales
+        run: |
+            sudo locale-gen en_US.UTF-8
+            sudo update-locale LANG=en_US.UTF-8
       - name: Check
         uses: actions/checkout@v2
       - run: pip install virtualenv

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,22 @@
+name: Run python-only unit tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test-assemblyline:
+    runs-on: ubuntu-latest
+    name: Run python only unit tests
+    env:
+      ISUNITTEST: true
+    steps:
+      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
+      - name: Check
+        uses: actions/checkout@v2
+      - run: pip install virtualenv
+      - run: virtualenv -p python3.8 .venv
+      - run: .venv/bin/pip install -r docassemble/ALToolbox/requirements.txt
+      - run: .venv/bin/pip install --editable .
+      - run: .venv/bin/python3 -m mypy .
+      - run: .venv/bin/python3 -m unittest discover

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -40,15 +40,15 @@ __all__ = [
 
 
 def _currency_float_to_decimal(value: Union[str, float]) -> Decimal:
-    """Given a float (that was set by a docassemble currency datatype, so truncated at 2 decimal places)
-    returns the correct decimal value, without floating point representation errors
+    """Given a float (that was set by a docassemble currency datatype, so
+    rounded to the nearest `fractional_digit` decimal places), returns the
+    exact decimal value, without floating point representation errors
     """
     if isinstance(value, float):
         # Print out the value of the float, rounded to the smallest allowable amount in the
         # locale currency, and use this value to make the exact Decimal value
         digits = get_locale("frac_digits")
-        format_str = "{:." + str(digits) + "f}"
-        return Decimal(format_str.format(value))
+        return Decimal(f"{value:.{digits}f}")
     else:
         return Decimal(value)
 

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -865,7 +865,7 @@ class ALItemizedJob(DAObject):
         if source:
             # Make sure we're always working with a list of sources (names?)
             # Add up all money coming in from a source
-            sources = self.source_to_list(source=source)
+            sources = self.source_to_set(source=source)
             for key, value in self.to_add.elements.items():
                 if key in sources:
                     total += self._item_value_per_times_per_year(
@@ -903,7 +903,7 @@ class ALItemizedJob(DAObject):
         if source:
             # Make sure we're always working with a list of sources (names?)
             # Add up all money coming in from a source
-            sources = self.source_to_list(source=source)
+            sources = self.source_to_set(source=source)
             for key, value in self.to_subtract.elements.items():
                 if key in sources:
                     total += self._item_value_per_times_per_year(
@@ -916,7 +916,7 @@ class ALItemizedJob(DAObject):
                     self._item_value_per_times_per_year(
                         item, times_per_year=times_per_year
                     )
-                    for item in self.to_subtract.elements
+                    for key, item in self.to_subtract.elements.items()
                 )
             )
 
@@ -940,24 +940,26 @@ class ALItemizedJob(DAObject):
             times_per_year=times_per_year, source=source
         ) - self.deduction_total(times_per_year=times_per_year, source=source)
 
-    def source_to_list(self, source: Union[List[str], str] = None) -> List[str]:
+    def source_to_set(self, source: Union[Set[str], List[str], str] = None) -> Set[str]:
         """
-        Returns list of the job's sources from both the `to_add` and
+        Returns set of the job's sources from both the `to_add` and
         `to_subtract`. You can filter the items by `source`. `source` can be a
         string or a list. E.g. "full time" or ["full time", "tips"]
 
         This is mostly for internal use meant to ensure that `source` input is
-        always a list.
+        always a set.
         """
-        sources: List = []
+        sources = set()
         # If not filtering by anything, get all possible sources
         if source is None:
-            sources = sources + [key for key in self.to_add.elements.keys()]
-            sources = sources + [key for key in self.to_subtract.elements.keys()]
-        elif isinstance(source, list):
+            sources.update([key for key in self.to_add.elements.keys()])
+            sources.update([key for key in self.to_subtract.elements.keys()])
+        elif isinstance(source, set):
             sources = source
+        elif isinstance(source, list):
+            sources = set(source)
         else:
-            sources = [source]
+            sources = set([source])
         return sources
 
     def employer_name_address_phone(self) -> str:

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -7,6 +7,7 @@ from docassemble.base.util import (
     DAEmpty,
     Individual,
     comma_list,
+    get_locale,
     log,
     object_name_convert,
     value,
@@ -36,6 +37,19 @@ __all__ = [
     "ALItemizedJob",
     "ALItemizedJobList",
 ]
+
+def _currency_float_to_decimal(value: Union[str, float]) -> Decimal:
+    """Given a float (that was set by a docassemble currency datatype, so truncated at 2 decimal places)
+    returns the correct decimal value, without floating point representation errors
+    """
+    if isinstance(value, float):
+        # Print out the value of the float, rounded to the smallest allowable amount in the
+        # locale currency, and use this value to make the exact Decimal value
+        digits = get_locale('frac_digits')
+        format_str  = '{:.' + str(digits) + 'f}'
+        return Decimal(format_str.format(value))
+    else:
+        return Decimal(value)
 
 
 def times_per_year(
@@ -107,7 +121,7 @@ class ALIncome(DAObject):
     is 1 (a year).
 
     Attributes:
-    .value {float | Decimal} A number representing an amount of money accumulated during
+    .value {str | float | Decimal} A number representing an amount of money accumulated during
         the `times_per_year` of this income.
     .times_per_year {float | Decimal} Represents a number of the annual frequency of
         the income. E.g. 12 for a monthly income.
@@ -127,21 +141,22 @@ class ALIncome(DAObject):
     def total(self, times_per_year: float = 1) -> Decimal:
         """
         Returns the income over the specified times_per_year, taking into account
-        hours per period for hourly items.
+        hours per period for hourly items. For example, for an hourly income of 10 
+        an hour, 40 hours a week, `income.total(1)` would be 20,800, the yearly income,
+        and `income.total(52)` would be 400, the weekly income. 
 
         To calculate `.total()`, an ALIncome must have a `.times_per_year` and `.value`.
         It can also have `.is_hourly` and `.hours_per_period`.
         """
+        val = _currency_float_to_decimal(self.value)
         if hasattr(self, "is_hourly") and self.is_hourly:
             return (
-                Decimal(self.value)
+                val
                 * Decimal(self.hours_per_period)
                 * Decimal(self.times_per_year)
             ) / Decimal(times_per_year)
         else:
-            return (Decimal(self.value) * Decimal(self.times_per_year)) / Decimal(
-                times_per_year
-            )
+            return (val * Decimal(self.times_per_year)) / Decimal(times_per_year)
 
 
 class ALIncomeList(DAList):
@@ -457,13 +472,13 @@ class ALAssetList(ALIncomeList):
         result = Decimal(0)
         for asset in self.elements:
             if source is None:
-                result += Decimal(asset.market_value)
+                result += _currency_float_to_decimal(asset.market_value)
             elif isinstance(source, list):
                 if asset.source in source:
-                    result += Decimal(asset.market_value)
+                    result += _currency_float_to_decimal(asset.market_value)
             else:
                 if asset.source == source:
-                    result += Decimal(asset.market_value)
+                    result += _currency_float_to_decimal(asset.market_value)
         return result
 
     def balance(self, source: Union[List[str], str] = None) -> Decimal:
@@ -478,13 +493,13 @@ class ALAssetList(ALIncomeList):
         result = Decimal(0)
         for asset in self.elements:
             if source is None:
-                result += Decimal(asset.balance)
+                result += _currency_float_to_decimal(asset.balance)
             elif isinstance(source, list):
                 if asset.source in source:
-                    result += Decimal(asset.balance)
+                    result += _currency_float_to_decimal(asset.balance)
             else:
                 if asset.source == source:
-                    result += Decimal(asset.balance)
+                    result += _currency_float_to_decimal(asset.balance)
         return result
 
     def owners(self, source: Union[List[str], str] = None) -> Set[str]:
@@ -558,7 +573,7 @@ class ALSimpleValue(DAObject):
         item in an ALSimpleValueList.
 
     Attributes:
-    .value {str} The monetary value of the item.
+    .value {str | float } The monetary value of the item.
     .transaction_type {str} (Optional) Can be "expense", which will give a
         negative value to the total of the item.
     .source {str} (Optional) The "source" of the item, like "vase".
@@ -573,14 +588,15 @@ class ALSimpleValue(DAObject):
         If you use signed values, be careful when placing in an ALIncomeList
         object. The `total()` method may return unexpected results in that case.
         """
+        val = _currency_float_to_decimal(self.value)
         if hasattr(self, "transaction_type"):
             return (
-                Decimal(self.value * -1)
+                val * Decimal(-1)
                 if (self.transaction_type == "expense")
-                else Decimal(self.value)
+                else val
             )
         else:
-            return Decimal(self.value)
+            return val
 
     def __str__(self):
         """Returns the total as a formatted string"""
@@ -614,15 +630,15 @@ class ALSimpleValueList(DAList):
         result = Decimal(0)
         if source is None:
             for value in self.elements:
-                result += Decimal(value.total())
+                result += value.total()
         elif isinstance(source, list):
             for value in self.elements:
                 if value.source in source:
-                    result += Decimal(value.total())
+                    result += value.total()
         else:
             for value in self.elements:
                 if value.source == source:
-                    result += Decimal(value.total())
+                    result += value.total()
         return result
 
 
@@ -649,6 +665,15 @@ class ALItemizedValue(DAObject):
         If the ".exists" attribute is False or undefined, the item will not be used
         when calculating totals.
     """
+
+    def total(self) -> Decimal:
+        # If an item's value doesn't exist, use a value of 0
+        # TODO: is this behavior correct, or should it force gathering the value?
+        # What does a no-value item in the list represent?
+        if not hasattr(self, 'value'):
+            return Decimal(0)
+
+        return _currency_float_to_decimal(self.value)
 
     def __str__(self):
         """Returns a string of the value of the item with two decimal places."""
@@ -806,22 +831,17 @@ class ALItemizedJob(DAObject):
         # Both the job and the item itself need to be hourly to be
         # calculated as hourly
         is_hourly = self.is_hourly and hasattr(item, "is_hourly") and item.is_hourly
-
-        # If an item's value doesn't exist, use a value of 0
-        # TODO: is this behavior correct, or should it force gathering the value?
-        # What does a no-value item in the list represent?
-        if hasattr(item, "value"):
-            value = Decimal(item.value)
-        else:
-            value = Decimal(0)
+        value = item.total()
 
         # Use the appropriate calculation
         if is_hourly:
-            return (
+            y = (
                 value * Decimal(self.hours_per_period) * Decimal(frequency_to_use)
             ) / Decimal(times_per_year)
+            return y
         else:
-            return (value * Decimal(frequency_to_use)) / Decimal(times_per_year)
+            y = (value * Decimal(frequency_to_use)) / Decimal(times_per_year)
+            return y
 
     def total(
         self, times_per_year: float = 1, source: Union[List[str], str] = None
@@ -865,7 +885,7 @@ class ALItemizedJob(DAObject):
                     self._item_value_per_times_per_year(
                         item, times_per_year=times_per_year
                     )
-                    for item in self.to_add.elements
+                    for key, item in self.to_add.elements.items()
                 )
             )
 

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -835,13 +835,11 @@ class ALItemizedJob(DAObject):
 
         # Use the appropriate calculation
         if is_hourly:
-            y = (
+            return (
                 value * Decimal(self.hours_per_period) * Decimal(frequency_to_use)
             ) / Decimal(times_per_year)
-            return y
         else:
-            y = (value * Decimal(frequency_to_use)) / Decimal(times_per_year)
-            return y
+            return (value * Decimal(frequency_to_use)) / Decimal(times_per_year)
 
     def total(
         self, times_per_year: float = 1, source: Union[List[str], str] = None

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -38,6 +38,7 @@ __all__ = [
     "ALItemizedJobList",
 ]
 
+
 def _currency_float_to_decimal(value: Union[str, float]) -> Decimal:
     """Given a float (that was set by a docassemble currency datatype, so truncated at 2 decimal places)
     returns the correct decimal value, without floating point representation errors
@@ -45,8 +46,8 @@ def _currency_float_to_decimal(value: Union[str, float]) -> Decimal:
     if isinstance(value, float):
         # Print out the value of the float, rounded to the smallest allowable amount in the
         # locale currency, and use this value to make the exact Decimal value
-        digits = get_locale('frac_digits')
-        format_str  = '{:.' + str(digits) + 'f}'
+        digits = get_locale("frac_digits")
+        format_str = "{:." + str(digits) + "f}"
         return Decimal(format_str.format(value))
     else:
         return Decimal(value)
@@ -141,9 +142,9 @@ class ALIncome(DAObject):
     def total(self, times_per_year: float = 1) -> Decimal:
         """
         Returns the income over the specified times_per_year, taking into account
-        hours per period for hourly items. For example, for an hourly income of 10 
+        hours per period for hourly items. For example, for an hourly income of 10
         an hour, 40 hours a week, `income.total(1)` would be 20,800, the yearly income,
-        and `income.total(52)` would be 400, the weekly income. 
+        and `income.total(52)` would be 400, the weekly income.
 
         To calculate `.total()`, an ALIncome must have a `.times_per_year` and `.value`.
         It can also have `.is_hourly` and `.hours_per_period`.
@@ -151,9 +152,7 @@ class ALIncome(DAObject):
         val = _currency_float_to_decimal(self.value)
         if hasattr(self, "is_hourly") and self.is_hourly:
             return (
-                val
-                * Decimal(self.hours_per_period)
-                * Decimal(self.times_per_year)
+                val * Decimal(self.hours_per_period) * Decimal(self.times_per_year)
             ) / Decimal(times_per_year)
         else:
             return (val * Decimal(self.times_per_year)) / Decimal(times_per_year)
@@ -590,11 +589,7 @@ class ALSimpleValue(DAObject):
         """
         val = _currency_float_to_decimal(self.value)
         if hasattr(self, "transaction_type"):
-            return (
-                val * Decimal(-1)
-                if (self.transaction_type == "expense")
-                else val
-            )
+            return val * Decimal(-1) if (self.transaction_type == "expense") else val
         else:
             return val
 
@@ -670,7 +665,7 @@ class ALItemizedValue(DAObject):
         # If an item's value doesn't exist, use a value of 0
         # TODO: is this behavior correct, or should it force gathering the value?
         # What does a no-value item in the list represent?
-        if not hasattr(self, 'value'):
+        if not hasattr(self, "value"):
             return Decimal(0)
 
         return _currency_float_to_decimal(self.value)

--- a/docassemble/ALToolbox/misc.py
+++ b/docassemble/ALToolbox/misc.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import docassemble.base.functions
 from docassemble.base.util import (
     defined,
@@ -36,8 +38,7 @@ class shortenMe:
 
 
 # The following three functions are from Quinten
-# format a float number to a whole number with thousands separator
-def thousands(num: float, show_decimals=False) -> str:
+def thousands(num: Union[float, str], show_decimals=False) -> str:
     """
     Return a whole number formatted with thousands separator.
     Optionally, format with 2 decimal points (for a PDF form with the
@@ -49,15 +50,14 @@ def thousands(num: float, show_decimals=False) -> str:
         else:
             return f"{int(num):,}"
     except:
-        return num
+        return str(num)
 
 
-# Format a phone number so you can click on it to open in your phone dialer
 def tel(phone_number):
+    """Format a phone number so you can click on it to open in your phone dialer"""
     return '<a href="tel:' + str(phone_number) + '">' + str(phone_number) + "</a>"
 
 
-# Display an icon on the screen.
 def fa_icon(icon, color="primary", color_css=None, size="sm"):
     """
     Return HTML for a font-awesome icon of the specified size and color. You can reference

--- a/docassemble/ALToolbox/requirements.txt
+++ b/docassemble/ALToolbox/requirements.txt
@@ -3,3 +3,4 @@ docassemble.webapp
 holidays>=0.13
 pandas>=1.4.2
 pandas-stubs
+mypy

--- a/docassemble/ALToolbox/requirements.txt
+++ b/docassemble/ALToolbox/requirements.txt
@@ -1,0 +1,5 @@
+docassemble.base>=1.4
+docassemble.webapp
+holidays>=0.13
+pandas>=1.4.2
+pandas-stubs

--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -22,8 +22,11 @@ def save_input_data(
     The input_dict should a dictionary where each key is a string and each value is a value from a Docassemble interview
     question. Typically that is a string, float, int, or a DADict.
     """
-    type_dict = dict()
-    field_dict = dict()
+    type_dict: Dict[str, str] = {}
+    field_dict: Dict[str, Any] = {}
+    if not input_dict:
+        # Can still save the tags, so just use an empty input dict
+        input_dict = {}
     for k, v in input_dict.items():
         field_dict[k] = v
         if isinstance(v, int):
@@ -35,7 +38,7 @@ def save_input_data(
         else:
             type_dict[k] = "text"
 
-    data_to_save = dict()
+    data_to_save: Dict[str, Any] = {}
     data_to_save["title"] = title
 
     # TODO(qs): We should be able to infer type in the InterviewStats package too, eventually. But

--- a/docassemble/ALToolbox/test_al_income.py
+++ b/docassemble/ALToolbox/test_al_income.py
@@ -8,57 +8,70 @@ from .al_income import (
     ALAssetList,
     ALVehicle,
     ALVehicleList,
-    ALSimpleValue, 
-    ALSimpleValueList, 
-    ALItemizedJob, 
-    ALItemizedValueDict, 
-    ALItemizedValue, 
-    recent_years
+    ALSimpleValue,
+    ALSimpleValueList,
+    ALItemizedJob,
+    ALItemizedValueDict,
+    ALItemizedValue,
+    recent_years,
 )
+
 
 class test_correct_outputs(unittest.TestCase):
     def test_simple_value(self):
-        value = ALSimpleValue(transaction_type='expense', value=5)
+        value = ALSimpleValue(transaction_type="expense", value=5)
         self.assertEqual(Decimal(-5), value.total())
-        value.transaction_type = 'asset'
+        value.transaction_type = "asset"
         self.assertEqual(Decimal(5), value.total())
 
-        value_str = ALSimpleValue(value='5.3')
-        self.assertEqual(Decimal('5.3'), value_str.total())
-        value_neg_str = ALSimpleValue(transaction_type='expense', value='5.3')
-        self.assertEqual(Decimal('-5.3'), value_neg_str.total())
+        value_str = ALSimpleValue(value="5.3")
+        self.assertEqual(Decimal("5.3"), value_str.total())
+        value_neg_str = ALSimpleValue(transaction_type="expense", value="5.3")
+        self.assertEqual(Decimal("-5.3"), value_neg_str.total())
         value_float = ALSimpleValue(value=6.3)
-        self.assertEqual(Decimal('6.3'), value_float.total())
+        self.assertEqual(Decimal("6.3"), value_float.total())
 
     def test_simple_value_list(self):
-        val1 = ALSimpleValue(transaction_type='expense', source='real estate', value=5)
-        val2 = ALSimpleValue(transaction_type='asset', source='job', value=10.1)
+        val1 = ALSimpleValue(transaction_type="expense", source="real estate", value=5)
+        val2 = ALSimpleValue(transaction_type="asset", source="job", value=10.1)
         val_list = ALSimpleValueList(elements=[val1, val2])
-        self.assertEqual(Decimal('5.1'), val_list.total())
-        self.assertSetEqual(set(['real estate', 'job']), val_list.sources())
-        val_list.elements.append(ALSimpleValue(transaction_type='asset', source='job', value=20.1))
-        self.assertSetEqual(set(['real estate', 'job']), val_list.sources())
+        self.assertEqual(Decimal("5.1"), val_list.total())
+        self.assertSetEqual(set(["real estate", "job"]), val_list.sources())
+        val_list.elements.append(
+            ALSimpleValue(transaction_type="asset", source="job", value=20.1)
+        )
+        self.assertSetEqual(set(["real estate", "job"]), val_list.sources())
 
     def test_income(self):
         income = ALIncome(value=10.1, times_per_year=12)
-        self.assertEqual(Decimal('121.2'), income.total())
-        self.assertEqual(Decimal('10.1'), income.total(times_per_year=12))
-        
-        hourly_income = ALIncome(value=4.4, times_per_year=52, is_hourly=True, hours_per_period=39)
-        self.assertEqual(Decimal('8923.2'), hourly_income.total())
-        self.assertEqual(Decimal('171.6'), hourly_income.total(52))
+        self.assertEqual(Decimal("121.2"), income.total())
+        self.assertEqual(Decimal("10.1"), income.total(times_per_year=12))
+
+        hourly_income = ALIncome(
+            value=4.4, times_per_year=52, is_hourly=True, hours_per_period=39
+        )
+        self.assertEqual(Decimal("8923.2"), hourly_income.total())
+        self.assertEqual(Decimal("171.6"), hourly_income.total(52))
 
     def test_income_list(self):
-        income = ALIncome(source='coding', value=12.53, times_per_year=12)
-        hourly_income = ALIncome(source='coding', value=4.4, times_per_year=2, is_hourly=True, hours_per_period=41)
+        income = ALIncome(source="coding", value=12.53, times_per_year=12)
+        hourly_income = ALIncome(
+            source="coding",
+            value=4.4,
+            times_per_year=2,
+            is_hourly=True,
+            hours_per_period=41,
+        )
         income_list = ALIncomeList(elements=[income, hourly_income])
-        self.assertSetEqual(set(['coding']), income_list.sources())
+        self.assertSetEqual(set(["coding"]), income_list.sources())
 
         self.assertEqual(Decimal(0), income_list.total(0))
-        self.assertEqual(Decimal('511.16'), income_list.total(1))
-        self.assertEqual(Decimal('511.16'), income_list.total(1, source='coding'))
-        self.assertEqual(Decimal(0), income_list.total(1, source='wrong job'))
-        self.assertEqual(Decimal('511.16'), income_list.total(1, source=['coding', 'wrong job']))
+        self.assertEqual(Decimal("511.16"), income_list.total(1))
+        self.assertEqual(Decimal("511.16"), income_list.total(1, source="coding"))
+        self.assertEqual(Decimal(0), income_list.total(1, source="wrong job"))
+        self.assertEqual(
+            Decimal("511.16"), income_list.total(1, source=["coding", "wrong job"])
+        )
 
     def test_job(self):
         # TODO
@@ -71,18 +84,25 @@ class test_correct_outputs(unittest.TestCase):
     def test_asset(self):
         home = ALAsset(market_value=1234567.89, source="home")
         self.assertEqual(Decimal(0), home.total())
-        savings = ALAsset(balance=12.34, value=0.12, times_per_year=12, source='savings account')
-        self.assertEqual(Decimal('1.44'), savings.total())
+        savings = ALAsset(
+            balance=12.34, value=0.12, times_per_year=12, source="savings account"
+        )
+        self.assertEqual(Decimal("1.44"), savings.total())
 
     def test_asset_list(self):
         home = ALAsset(market_value=1234567.89, source="home")
-        savings = ALAsset(balance=12.34, value=0.12, times_per_year=12, source='savings')
-        investing = ALAsset(balance=23.45, value=1.2, times_per_year=12, source='stocks')
+        savings = ALAsset(
+            balance=12.34, value=0.12, times_per_year=12, source="savings"
+        )
+        investing = ALAsset(
+            balance=23.45, value=1.2, times_per_year=12, source="stocks"
+        )
         asset_list = ALAssetList(elements=[home, savings, investing])
-        self.assertEqual(Decimal('1234567.89'), asset_list.market_value(source='home'))
-        self.assertEqual(Decimal('35.79'), asset_list.balance(source=['savings', 'stocks']))
-        self.assertEqual(Decimal('15.84'), asset_list.total())
-
+        self.assertEqual(Decimal("1234567.89"), asset_list.market_value(source="home"))
+        self.assertEqual(
+            Decimal("35.79"), asset_list.balance(source=["savings", "stocks"])
+        )
+        self.assertEqual(Decimal("15.84"), asset_list.total())
 
     def test_vehicle(self):
         # TODO
@@ -93,22 +113,34 @@ class test_correct_outputs(unittest.TestCase):
         pass
 
     def test_itemized_value_dict(self):
-        itemized_dict = ALItemizedValueDict(elements={
-            'val1': ALItemizedValue(value=5.30, exists=True, is_hourly=False, times_per_year=1),
-            'val2': ALItemizedValue(value=5.30, exists=False, is_hourly=False, times_per_year=1),
-        })
+        itemized_dict = ALItemizedValueDict(
+            elements={
+                "val1": ALItemizedValue(
+                    value=5.30, exists=True, is_hourly=False, times_per_year=1
+                ),
+                "val2": ALItemizedValue(
+                    value=5.30, exists=False, is_hourly=False, times_per_year=1
+                ),
+            }
+        )
         itemized_dict.hook_after_gather()
         self.assertEqual(1, len(itemized_dict))
 
     def test_itemized_job(self):
-        job = ALItemizedJob(is_hourly=True, is_part_time=True, name="Baby sitter", source="job", times_per_year=52)
-        job.to_add['part time'] = ALItemizedValue(is_hourly = True, value=10.04)
+        job = ALItemizedJob(
+            is_hourly=True,
+            is_part_time=True,
+            name="Baby sitter",
+            source="job",
+            times_per_year=52,
+        )
+        job.to_add["part time"] = ALItemizedValue(is_hourly=True, value=10.04)
         job.hours_per_period = 10
-        self.assertEqual(Decimal('5220.8'), job.gross_total())
+        self.assertEqual(Decimal("5220.8"), job.gross_total())
 
     def test_itemized_job_list(self):
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/docassemble/ALToolbox/test_al_income.py
+++ b/docassemble/ALToolbox/test_al_income.py
@@ -144,7 +144,6 @@ class test_correct_outputs(unittest.TestCase):
         self.assertEqual(Decimal("14373.84"), job.net_total())
         self.assertSetEqual(set(["part time", "tips", "snacks"]), job.source_to_set())
 
-
     def test_itemized_job_list(self):
         # TODO
         pass

--- a/docassemble/ALToolbox/test_al_income.py
+++ b/docassemble/ALToolbox/test_al_income.py
@@ -136,9 +136,17 @@ class test_correct_outputs(unittest.TestCase):
         )
         job.to_add["part time"] = ALItemizedValue(is_hourly=True, value=10.04)
         job.hours_per_period = 10
-        self.assertEqual(Decimal("5220.8"), job.gross_total())
+        self.assertEqual(Decimal("5220.80"), job.gross_total())
+        job.to_add["tips"] = ALItemizedValue(is_hourly=False, value=200.23)
+        job.to_subtract["snacks"] = ALItemizedValue(is_hourly=False, value="24.21")
+        self.assertEqual(Decimal("15632.76"), job.gross_total())
+        self.assertEqual(Decimal("1258.92"), job.deduction_total())
+        self.assertEqual(Decimal("14373.84"), job.net_total())
+        self.assertSetEqual(set(["part time", "tips", "snacks"]), job.source_to_set())
+
 
     def test_itemized_job_list(self):
+        # TODO
         pass
 
 

--- a/docassemble/ALToolbox/test_al_income.py
+++ b/docassemble/ALToolbox/test_al_income.py
@@ -30,6 +30,7 @@ class test_correct_outputs(unittest.TestCase):
         self.assertEqual(Decimal("-5.3"), value_neg_str.total())
         value_float = ALSimpleValue(value=6.3)
         self.assertEqual(Decimal("6.3"), value_float.total())
+        self.assertEqual("6.30", str(value_float.total()))
 
     def test_simple_value_list(self):
         val1 = ALSimpleValue(transaction_type="expense", source="real estate", value=5)
@@ -46,6 +47,7 @@ class test_correct_outputs(unittest.TestCase):
         income = ALIncome(value=10.1, times_per_year=12)
         self.assertEqual(Decimal("121.2"), income.total())
         self.assertEqual(Decimal("10.1"), income.total(times_per_year=12))
+        self.assertEqual(Decimal("2.33"), income.total(times_per_year=52).quantize(Decimal('0.01')))
 
         hourly_income = ALIncome(
             value=4.4, times_per_year=52, is_hourly=True, hours_per_period=39
@@ -140,8 +142,10 @@ class test_correct_outputs(unittest.TestCase):
         job.to_add["tips"] = ALItemizedValue(is_hourly=False, value=200.23)
         job.to_subtract["snacks"] = ALItemizedValue(is_hourly=False, value="24.21")
         self.assertEqual(Decimal("15632.76"), job.gross_total())
+        self.assertEqual("15632.76", str(job.gross_total()))
         self.assertEqual(Decimal("1258.92"), job.deduction_total())
         self.assertEqual(Decimal("14373.84"), job.net_total())
+        self.assertEqual("14373.84", str(job.net_total()))
         self.assertSetEqual(set(["part time", "tips", "snacks"]), job.source_to_set())
 
     def test_itemized_job_list(self):

--- a/docassemble/ALToolbox/test_al_income.py
+++ b/docassemble/ALToolbox/test_al_income.py
@@ -47,7 +47,9 @@ class test_correct_outputs(unittest.TestCase):
         income = ALIncome(value=10.1, times_per_year=12)
         self.assertEqual(Decimal("121.2"), income.total())
         self.assertEqual(Decimal("10.1"), income.total(times_per_year=12))
-        self.assertEqual(Decimal("2.33"), income.total(times_per_year=52).quantize(Decimal('0.01')))
+        self.assertEqual(
+            Decimal("2.33"), income.total(times_per_year=52).quantize(Decimal("0.01"))
+        )
 
         hourly_income = ALIncome(
             value=4.4, times_per_year=52, is_hourly=True, hours_per_period=39

--- a/docassemble/ALToolbox/test_al_income.py
+++ b/docassemble/ALToolbox/test_al_income.py
@@ -1,0 +1,114 @@
+import unittest
+
+from decimal import Decimal
+from .al_income import (
+    ALIncome,
+    ALIncomeList,
+    ALAsset,
+    ALAssetList,
+    ALVehicle,
+    ALVehicleList,
+    ALSimpleValue, 
+    ALSimpleValueList, 
+    ALItemizedJob, 
+    ALItemizedValueDict, 
+    ALItemizedValue, 
+    recent_years
+)
+
+class test_correct_outputs(unittest.TestCase):
+    def test_simple_value(self):
+        value = ALSimpleValue(transaction_type='expense', value=5)
+        self.assertEqual(Decimal(-5), value.total())
+        value.transaction_type = 'asset'
+        self.assertEqual(Decimal(5), value.total())
+
+        value_str = ALSimpleValue(value='5.3')
+        self.assertEqual(Decimal('5.3'), value_str.total())
+        value_neg_str = ALSimpleValue(transaction_type='expense', value='5.3')
+        self.assertEqual(Decimal('-5.3'), value_neg_str.total())
+        value_float = ALSimpleValue(value=6.3)
+        self.assertEqual(Decimal('6.3'), value_float.total())
+
+    def test_simple_value_list(self):
+        val1 = ALSimpleValue(transaction_type='expense', source='real estate', value=5)
+        val2 = ALSimpleValue(transaction_type='asset', source='job', value=10.1)
+        val_list = ALSimpleValueList(elements=[val1, val2])
+        self.assertEqual(Decimal('5.1'), val_list.total())
+        self.assertSetEqual(set(['real estate', 'job']), val_list.sources())
+        val_list.elements.append(ALSimpleValue(transaction_type='asset', source='job', value=20.1))
+        self.assertSetEqual(set(['real estate', 'job']), val_list.sources())
+
+    def test_income(self):
+        income = ALIncome(value=10.1, times_per_year=12)
+        self.assertEqual(Decimal('121.2'), income.total())
+        self.assertEqual(Decimal('10.1'), income.total(times_per_year=12))
+        
+        hourly_income = ALIncome(value=4.4, times_per_year=52, is_hourly=True, hours_per_period=39)
+        self.assertEqual(Decimal('8923.2'), hourly_income.total())
+        self.assertEqual(Decimal('171.6'), hourly_income.total(52))
+
+    def test_income_list(self):
+        income = ALIncome(source='coding', value=12.53, times_per_year=12)
+        hourly_income = ALIncome(source='coding', value=4.4, times_per_year=2, is_hourly=True, hours_per_period=41)
+        income_list = ALIncomeList(elements=[income, hourly_income])
+        self.assertSetEqual(set(['coding']), income_list.sources())
+
+        self.assertEqual(Decimal(0), income_list.total(0))
+        self.assertEqual(Decimal('511.16'), income_list.total(1))
+        self.assertEqual(Decimal('511.16'), income_list.total(1, source='coding'))
+        self.assertEqual(Decimal(0), income_list.total(1, source='wrong job'))
+        self.assertEqual(Decimal('511.16'), income_list.total(1, source=['coding', 'wrong job']))
+
+    def test_job(self):
+        # TODO
+        pass
+
+    def test_job_list(self):
+        # TODO
+        pass
+
+    def test_asset(self):
+        home = ALAsset(market_value=1234567.89, source="home")
+        self.assertEqual(Decimal(0), home.total())
+        savings = ALAsset(balance=12.34, value=0.12, times_per_year=12, source='savings account')
+        self.assertEqual(Decimal('1.44'), savings.total())
+
+    def test_asset_list(self):
+        home = ALAsset(market_value=1234567.89, source="home")
+        savings = ALAsset(balance=12.34, value=0.12, times_per_year=12, source='savings')
+        investing = ALAsset(balance=23.45, value=1.2, times_per_year=12, source='stocks')
+        asset_list = ALAssetList(elements=[home, savings, investing])
+        self.assertEqual(Decimal('1234567.89'), asset_list.market_value(source='home'))
+        self.assertEqual(Decimal('35.79'), asset_list.balance(source=['savings', 'stocks']))
+        self.assertEqual(Decimal('15.84'), asset_list.total())
+
+
+    def test_vehicle(self):
+        # TODO
+        pass
+
+    def test_vehicle_list(self):
+        # TODO
+        pass
+
+    def test_itemized_value_dict(self):
+        itemized_dict = ALItemizedValueDict(elements={
+            'val1': ALItemizedValue(value=5.30, exists=True, is_hourly=False, times_per_year=1),
+            'val2': ALItemizedValue(value=5.30, exists=False, is_hourly=False, times_per_year=1),
+        })
+        itemized_dict.hook_after_gather()
+        self.assertEqual(1, len(itemized_dict))
+
+    def test_itemized_job(self):
+        job = ALItemizedJob(is_hourly=True, is_part_time=True, name="Baby sitter", source="job", times_per_year=52)
+        job.to_add['part time'] = ALItemizedValue(is_hourly = True, value=10.04)
+        job.hours_per_period = 10
+        self.assertEqual(Decimal('5220.8'), job.gross_total())
+
+    def test_itemized_job_list(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docassemble/ALToolbox/test_altoolbox.py
+++ b/docassemble/ALToolbox/test_altoolbox.py
@@ -2,6 +2,7 @@ import unittest
 from .business_days import is_business_day, get_next_business_day
 from docassemble.base.util import today
 
+
 class TestBusinessDays(unittest.TestCase):
     def test_is_business_day(self):
         self.assertFalse(is_business_day("2022-09-05"))
@@ -9,5 +10,6 @@ class TestBusinessDays(unittest.TestCase):
         this_years_christmas = today().replace(month=12, day=25)
         self.assertFalse(is_business_day(this_years_christmas))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/docassemble/ALToolbox/test_altoolbox.py
+++ b/docassemble/ALToolbox/test_altoolbox.py
@@ -2,10 +2,12 @@ import unittest
 from .business_days import is_business_day, get_next_business_day
 from docassemble.base.util import today
 
-
 class TestBusinessDays(unittest.TestCase):
     def test_is_business_day(self):
-        self.assertFalse(is_business_day("2022-0-05"))
+        self.assertFalse(is_business_day("2022-09-05"))
         self.assertTrue(is_business_day("2022-09-06"))
         this_years_christmas = today().replace(month=12, day=25)
         self.assertFalse(is_business_day(this_years_christmas))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,3 @@ ignore_missing_imports = True
 
 [mypy-pycountry]
 ignore_missing_imports = True
-
-[mypy-pandas]
-ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,20 @@
+# global options
+
+[mypy]
+exclude = (?x)(
+    ^setup.py$
+  )
+
+# per-module options:
+
+[mypy-docassemble.webapp.*]
+ignore_missing_imports = True
+
+[mypy-docassemble.base.*]
+ignore_missing_imports = True
+
+[mypy-pycountry]
+ignore_missing_imports = True
+
+[mypy-pandas]
+ignore_missing_imports = True


### PR DESCRIPTION
* Decimal floating point rep errors (fixes #99)
  Get the locale's `frac_digits`, which is the number of fractional digits in currency, and always rounds to it when using floats. This is safe if being used on inputs from docassemble's `currency` datatype, which truncates the user typed value to that number of digits (but still stores it in a float).
  Some notable examples of locales that don't use 2 digits of fractional currency (from [Locale Helper](https://lh.2xlibre.net/values/frac_digits/)):
  * all arabic locales use 3 digits
  * Japan, Korea, and Iceland use 0 digits (i.e. all round numbers)
* `total()` in itemized job not working:
  Was iterating over the dictionary itself, which just gives the keys (i.e. the sources / names), not the item itself. Didn't error because we're checking `hasattr(item, 'value')` before doing much else, assuming that the given value wasn't a string. Fixes by iterating over `items()` instead.

* Started running `mypy` and `unittest` in github actions, to ensure tests are run on each commit.
  * fixed a few other mypy issues still in the repository
  * adjusted workflow script to properly set the right locale (which we depend on being set to 2 for the unittests).