### PR TITLE
More income module changes

### DIFF
--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -27,7 +27,7 @@ __all__ = [
     "ALIncome",
     "ALIncomeList",
     "ALExpense",
-    "ALExpenses",
+    "ALExpenseList",
     "ALJob",
     "ALJobList",
     "ALAsset",
@@ -323,14 +323,13 @@ class ALIncomeList(DAList):
         if not selected_terms:
             selected_terms = {}
         self.elements.clear()
-        if selected_types.any_true():
-            for source in selected_types.true_values():
-                if source == "other":
-                    self.appendObject()
-                else:
-                    self.appendObject(
-                        source=source, display_name=selected_terms.get(source, source)
-                    )
+        for source in selected_types.true_values():
+            if source == "other":
+                self.appendObject()
+            else:
+                self.appendObject(
+                    source=source, display_name=selected_terms.get(source, source)
+                )
         self.moved = True
 
 

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -504,7 +504,7 @@ class ALJobList(ALIncomeList):
         return result
 
 
-class ALExpenses(ALIncomeList):
+class ALExpenseList(ALIncomeList):
     """
     A list of expenses
 

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -141,7 +141,7 @@ class ALPeriodicAmount(DAObject):
 
     def total(self, times_per_year: float = 1) -> Decimal:
         """
-        Returns the income over the specified times_per_year, 
+        Returns the income over the specified times_per_year,
 
         To calculate `.total()`, an ALPeriodicAmount must have a `.times_per_year` and `.value`.
         """
@@ -188,8 +188,10 @@ class ALIncome(ALPeriodicAmount):
         else:
             return super().total(times_per_year=times_per_year)
 
+
 class ALExpense(ALPeriodicAmount):
     """Not much changes from ALPeriodic Amount, just the generic object questions"""
+
     pass
 
 
@@ -253,7 +255,9 @@ class ALIncomeList(DAList):
                 sources.add(item.source)
         return sources
 
-    def matches(self, source: SourceType, exclude_source: SourceType=None) -> "ALIncomeList":
+    def matches(
+        self, source: SourceType, exclude_source: SourceType = None
+    ) -> "ALIncomeList":
         """
         Returns an ALIncomeList consisting only of elements matching the specified
         income source, assisting in filling PDFs with predefined spaces. `source`
@@ -288,7 +292,9 @@ class ALIncomeList(DAList):
             return result
         satisfies_sources = _source_to_callable(source, exclude_source)
         for item in self.elements:
-            if (source is None and exclude_source is None) or (hasattr(item, "source") and satisfies_sources(item.source)):
+            if (source is None and exclude_source is None) or (
+                hasattr(item, "source") and satisfies_sources(item.source)
+            ):
                 if owner is None:  # if the user doesn't care who the owner is
                     result += Decimal(item.total(times_per_year=times_per_year))
                 else:
@@ -300,13 +306,15 @@ class ALIncomeList(DAList):
                         result += Decimal(item.total(times_per_year=times_per_year))
         return result
 
-    def move_checks_to_list(self, selected_types: DADict=None, selected_terms: Mapping=None):
+    def move_checks_to_list(
+        self, selected_types: DADict = None, selected_terms: Mapping = None
+    ):
         """Gives a 'gather by checklist' option.
         If no selected_types param is passed, requires that a .selected_types
         attribute be set by a `datatype: checkboxes` fields
         If "other" is in the selected_types, the source will not be set directly
-        
-        Sets the attribute "moved" to true, doesn't set gathered, because this isn't 
+
+        Sets the attribute "moved" to true, doesn't set gathered, because this isn't
         idempotent, so trying to also gather all info about the checks in the list doesn't
         work well.
         """
@@ -320,9 +328,10 @@ class ALIncomeList(DAList):
                 if source == "other":
                     self.appendObject()
                 else:
-                    self.appendObject(source=source, display_name=selected_terms.get(source, source))
+                    self.appendObject(
+                        source=source, display_name=selected_terms.get(source, source)
+                    )
         self.moved = True
-
 
 
 class ALJob(ALIncome):
@@ -354,7 +363,7 @@ class ALJob(ALIncome):
 
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
-        #if not hasattr(self, "source") or self.source is None:
+        # if not hasattr(self, "source") or self.source is None:
         #    self.source = "job"
         if not hasattr(self, "employer"):
             if hasattr(self, "employer_type"):
@@ -494,6 +503,7 @@ class ALJobList(ALIncomeList):
                 result += Decimal(job.net_total(times_per_year=times_per_year))
         return result
 
+
 class ALExpenses(ALIncomeList):
     """
     A list of expenses
@@ -503,6 +513,7 @@ class ALExpenses(ALIncomeList):
         * owner
         * display name
     """
+
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.object_type = ALExpense
@@ -566,7 +577,9 @@ class ALAssetList(ALIncomeList):
         result = Decimal(0)
         satisfies_sources = _source_to_callable(source, exclude_source)
         for asset in self.elements:
-            if (source is None and exclude_source is None) or (satisfies_sources(asset.source)):
+            if (source is None and exclude_source is None) or (
+                satisfies_sources(asset.source)
+            ):
                 result += _currency_float_to_decimal(asset.market_value)
         return result
 
@@ -584,7 +597,9 @@ class ALAssetList(ALIncomeList):
         result = Decimal(0)
         satisfies_sources = _source_to_callable(source, exclude_source)
         for asset in self.elements:
-            if (source is None and exclude_source is None) or (satisfies_sources(asset.source)):
+            if (source is None and exclude_source is None) or (
+                satisfies_sources(asset.source)
+            ):
                 result += _currency_float_to_decimal(asset.balance)
         return result
 
@@ -918,7 +933,7 @@ class ALItemizedJob(DAObject):
 
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
-        #if not hasattr(self, "source") or self.source is None:
+        # if not hasattr(self, "source") or self.source is None:
         #    self.source = "job"
         if not hasattr(self, "employer"):
             if hasattr(self, "employer_type"):

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -15,11 +15,20 @@ data:
   - [2, "Once every 6 months"]
   - [1, "Yearly"]
 ---
-objects:
-  # a list of asset sources for a multiple choice dropdown
-  - asset_source_list: DAOrderedDict.using(elements=asset_list_dict, auto_gather = False, gathered = True)
+variable name: times_per_year_for_expenses
+data:
+  - [365, "Daily"]
+  - [260, "Every weekday"]
+  - [104, "Twice Weekly"]
+  - [52, "Weekly"]
+  - [26, "Once every two weeks"]
+  - [24, "Twice per month"]
+  - [12, "Monthly"]
+  - [4, "Once every 3 months"]
+  - [2, "Once every 6 months"]
+  - [1, "Yearly"]
 ---
-variable name: asset_list_dict
+variable name: asset_terms
 data: !!omap
   - checking: "Checking Account"
   - savings: "Savings Account"
@@ -32,27 +41,26 @@ data: !!omap
   - real estate: "Real Estate"
   - other: "Other Asset"
 ---
-objects:
-  # dict of income sources for a multiple choice dropdown
-  - income_source_list: DAOrderedDict.using(elements=income_list_dict, auto_gather = False, gathered = True)
+variable name: account_terms
+data: !!omap
+  - checking: "Checking Account"
+  - savings: "Savings Account"
+  - cd: "Certificate of Deposit"
+  - ira: "Individual Retirement Account (IRA)"
+  - mutual fund: "Money or Mutual Fund"
+  - stocks: "Stocks or Bonds"
+  - trust: "Trust Fund"
 ---
-variable name: income_list_dict
+objects:
+  # ordered list of asset sources for a multiple choice dropdown
+  - account_terms_ordered: DAOrderedDict.using(elements=account_terms, auto_gather=False, gathered=True)
+  - asset_terms_ordered: DAOrderedDict.using(elements={**account_terms, **asset_terms}, auto_gather=False, gathered=True)
+---
+variable name: income_terms
 data: !!omap
   - wages: "A job or self-employment"
 ---
-code: |
-  income_source_list.elements.update(non_wage_income_list)
-  update_income_list = True
----
-mandatory: True
-code: |
-  update_income_list
----
-objects:
-  # a dict of income sources, excluding wages
-  - non_wage_income_list: DAOrderedDict.using(elements=non_wage_income_list_dict, auto_gather = False, gathered = True)
----
-variable name: non_wage_income_list_dict
+variable name: non_wage_income_terms
 data: !!omap
   - SSR: "Social Security Retirement Benefits"
   - SSDI: "Social Security Disability Benefits"
@@ -69,10 +77,12 @@ data: !!omap
   - other: "Other"
 ---
 objects:
-  # a dict of expense sources for a multiple choice dropdown
-  - expense_source_list: DAOrderedDict.using(elements=expense_list_dict, auto_gather = False, gathered = True)
+  # dict of income sources for a multiple choice dropdown
+  - income_terms_ordered: DAOrderedDict.using(elements={**income_terms, **non_wage_income_terms}, auto_gather=False, gathered=True)
+  # a dict of income sources, excluding wages
+  - non_wage_income_terms_ordered: DAOrderedDict.using(elements=non_wage_income_terms, auto_gather = False, gathered = True)
 ---
-variable name: expense_list_dict
+variable name: expense_terms
 data: !!omap
   - rent: "Rent"
   - mortgage: "Mortgage"
@@ -83,14 +93,18 @@ data: !!omap
   - credit cards: "Credit Card Payments"
   - property tax: "Property Tax (State and Local)"
   - other taxes: "Other taxes and fees related to your home"
-  - insurance: "Insurance"
-  - medical: "Medical-Dental (after amount paid by insurance)"
+  - medical_insurance: "Medical Insurance (including health, dental, and vision)"
+  - medical: "Medical costs (after amount paid by insurance)"
   - auto: "Car operation and maintenance"
   - transportation: "Other transportation"
   - charity: "Church or charitable donations"
   - loan payments: "Loan, credit, or lay-away payments"
   - support: "Support to someone not in household"
   - other: "Other"
+---
+objects:
+  # a dict of expense sources for a multiple choice dropdown
+  - expense_terms_ordered: DAOrderedDict.using(elements=expense_terms, auto_gather = False, gathered = True)
 ---
 ########## Questions
 ---
@@ -114,9 +128,23 @@ columns:
 edit:
   - exists
 ---
+generic object: ALExpenses 
+table: x.table
+rows: x
+columns:
+  - Type: |
+      row_index
+  - Amount: |
+      '$0' if hasattr(row_item, 'exists') and not row_item.exists else currency(row_item.value)
+edit:
+  - source
+  - value
+---
 generic object: ALItemizedJob
 code: |
   x.source
+  x.is_self_employed
+  # NOTE: if `is_self_employed`, you need to set this yourself
   x.employer.name.first
   x.times_per_year
   x.to_add.complete_attribute = 'complete'
@@ -127,6 +155,12 @@ code: |
     x.to_add["full time"].is_hourly = x.is_hourly
   x.to_add.gather()
   x.to_subtract.gather()
+  x.complete = True
+---
+generic object: ALIncome
+code: |
+  x.source
+  x.value
   x.complete = True
 ---
 generic object: ALItemizedJob
@@ -153,19 +187,42 @@ generic object: ALItemizedJob
 question: |
   Tell us who employs you as a ${ x.source }
 fields:
+  - I am self-employed: x.is_self_employed
+    datatype: yesno
   - Name: x.employer.name.first
+    show if:
+      variable: x.is_self_employed
+      is: False
   - Street: x.employer.address.address
     required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
   - Unit: x.employer.address.unit
     required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
   - City: x.employer.address.city
     required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
   - State: x.employer.address.state
     required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
   - Zip: x.employer.address.zip
     required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
   - Phone number: x.employer.phone_number
     required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
 ---
 id: itemized job line items
 generic object: ALItemizedJob
@@ -192,9 +249,6 @@ fields:
       datatype: currency
       show if:
         code: x.is_part_time is True
-    - What are your tips for this job?: x.to_add['tips'].value
-      datatype: currency
-      required: False
     - What is your federal tax amount?: x.to_subtract['federal_taxes'].value
       datatype: currency
       required: False
@@ -206,10 +260,12 @@ fields:
     - Does the job have other deductions?: x.to_subtract.there_is_another
       datatype: yesnoradio
 ---
+comment: |
+  Lesser wording, but it has to be passive because we don't have the individual's name
 id: itemized job period
 generic object: ALItemizedJob
 question: |
-  Tell us about your hours when working as a ${ x.source }
+  Tell us about the hours when working as a ${ x.source }
 fields:
   - Is this a part time job: x.is_part_time
     datatype: yesnoradio
@@ -218,14 +274,56 @@ fields:
     choices:
       - Hourly: True
       - Salary: False
-  - How often do you get paid?: x.times_per_year
+  - How often does ${ x.employer} pay?: x.times_per_year
     input type: radio
     code: |
       times_per_year_list
     datatype: integer
-  - How many hours do you work during that time?: x.hours_per_period
+  - How many hours are worked during that time?: x.hours_per_period
     input type: number
     show if: x.is_hourly
+---
+id: itemized job period
+generic object: Individual
+question: |
+  Tell us about ${ x }'s hours when working as a ${ x.jobs[i].source }
+fields:
+  - Is this a part time job: x.jobs[i].is_part_time
+    datatype: yesnoradio
+  - Hourly or salary?: x.jobs[i].is_hourly
+    input type: radio
+    choices:
+      - Hourly: True
+      - Salary: False
+  - How often does ${ x } get paid?: x.jobs[i].times_per_year
+    input type: radio
+    code: |
+      times_per_year_list
+    datatype: integer
+  - How many hours does ${ x } work during that time?: x.jobs[i].hours_per_period
+    input type: number
+    show if: x.jobs[i].is_hourly
+---
+id: itemized job period
+question: |
+  Tell us about your hours when working as a ${ users[0].jobs[i].source }
+fields:
+  - Is this a part time job: users[0].jobs[i].is_part_time
+    datatype: yesnoradio
+  - Hourly or salary?: users[0].jobs[i].is_hourly
+    input type: radio
+    choices:
+      - Hourly: True
+      - Salary: False
+  - How often do you get paid?: users[0].jobs[i].times_per_year
+    input type: radio
+    code: |
+      times_per_year_list
+    datatype: integer
+  - How many hours do you work during that time?: users[0].jobs[i].hours_per_period
+    input type: number
+    show if: users[0].jobs[i].is_hourly
+
 ---
 #id: other itemized job income name
 generic object: ALItemizedJob
@@ -283,6 +381,20 @@ fields:
   - no label: x.to_subtract.there_is_another
     datatype: yesnoradio
 ---
+generic object: ALItemizedJob
+code: |
+  x.to_subtract[i].exists
+  if x.to_subtract[i].exists:
+    x.to_subtract[i].value
+  x.to_subtract[i].complete = True
+---
+comment: |
+  Necessary for items in `to_subtract` that are already
+  in the question for common ones
+generic object: ALItemizedJob
+code: |
+  x.to_subtract[i].exists = True
+---
 # UNIQUE ITEMS FOR ALItemizedJobList
 ---
 id: how many itemized jobs
@@ -322,9 +434,9 @@ columns:
   - Employer: |
       row_item.employer.name if hasattr(row_item.employer.name, "first") else ""
   - Annual Gross Income: |
-      row_item.gross_total()
+      currency(row_item.gross_total())
   - Annual Deductions: |
-      row_item.deduction_total()
+      currency(row_item.deduction_total())
 edit:
   - source
   - employer.name.first
@@ -388,7 +500,7 @@ fields:
   - no label: x.selected_types
     datatype: checkboxes
     code: |
-      expense_list_dict
+      expense_terms_ordered
 ---
 generic object: ALExpenses
 id: expense information
@@ -397,13 +509,17 @@ question: |
 fields: 
   - Type of expense: x[i].source
     code: |
-      expense_list_dict
+      expense_terms_ordered
+  - Describe your expense: x[i].source
+    show if:
+      variable: x[i].source
+      is: other
   - Amount: x[i].value
     datatype: currency
   - How often do you pay this amount?: x[i].times_per_year
     default: 12
     code: |
-      times_per_year_list()
+      times_per_year_for_expenses
 ---
 generic object: ALExpenses
 need:
@@ -444,7 +560,14 @@ fields:
 generic object: ALExpenses
 code: |
   x.selected_types
-  x.move_checks_to_list(expense_list_dict)
+  x.move_checks_to_list(selected_terms=expense_terms)
+  x.moved = True
+---
+generic object: ALExpenses
+code: |
+  x.moved
+  for exp in x.elements:
+    exp.value
   x.revisit = True
   x.gathered = True
 ---
@@ -453,12 +576,18 @@ table: x.table
 rows: x
 columns:
   - Type: |
-      x.display_name
+      row_item.display_name
   - Amount per month: |
-      x.total(times_per_year=12)
+      currency(row_item.total(times_per_year=12))
 edit:
-  - type
+  - source
   - value
+---
+comment: |
+  For "other"
+generic object: ALExpense
+code: |
+  x.display_name = x.source
 ---
 generic object: ALExpenses
 id: revisit expenses
@@ -478,14 +607,15 @@ fields:
   - no label: income_sources
     datatype: checkboxes
     code: |
-      income_source_list
+      income_terms_ordered
 ---
 # SHARED BY ALJob AND ALJobList
 ---
 generic object: ALJob
 code: |
+  x.is_self_employed
+  x.employer.name.first
   x.source
-  x.employer
   x.value
   x.complete = True
 ---
@@ -499,11 +629,44 @@ fields:
 id: regular job employer
 generic object: ALJob
 question: |
-  Tell us about who employs you as a ${ x.source }
+  Who employs you as a ${ x.source }
 fields:
-  - Name: x.employer
-  - Address: x.employer_address
-  - Phone: x.employer_phone
+  - I am self-employed: x.is_self_employed
+    datatype: yesno
+  - First name: x.employer.name.first
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Last name: x.employer.name.last
+    required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Street address: x.employer.address.address
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Unit: x.employer.address.unit 
+    show if:
+      variable: x.is_self_employed
+      is: False
+    required: False
+  - City: x.employer.address.city
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - State: x.employer.address.state
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Postal code: x.employer.address.zip
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Phone: x.employer.phone
+    show if:
+      variable: x.is_self_employed
+      is: False
 ---
 id: regular job value
 generic object: ALJob
@@ -561,7 +724,7 @@ question: |
 fields:
   - What type of asset is it?: x.source
     code: |
-      asset_source_list
+      asset_terms_ordered
     exclude: |
       ['vehicle']
   - How often do you get this income?: x.times_per_year

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -12,6 +12,7 @@ data:
   - [24, "Twice per month"]
   - [12, "Monthly"]
   - [4, "Once every 3 months"]
+  - [2, "Once every 6 months"]
   - [1, "Yearly"]
 ---
 objects:
@@ -233,18 +234,23 @@ question: |
 subquestion: |
   You have already told us about your income from **${comma_and_list( [job_items_names.get(key, key).lower() for key in x.to_add.complete_elements().keys()] )}**.
 fields:
-  - Income name: x.to_add.new_item_name
+  - Type of income: x.to_add.new_item_name
 validation code: |
   if x.to_add.new_item_name in x.to_add.complete_elements().keys():
-    validation_error(f'You already told us about your <strong>{ job_items_names.get(x.to_add.new_item_name, x.to_add.new_item_name) }</strong> that pay { currency( x.to_add[ x.to_add.new_item_name ].value )}. Pick a different name.')
+    validation_error(f'You already told us about your <strong>{ job_items_names.get(x.to_add.new_item_name, x.to_add.new_item_name) }</strong> that pays { currency( x.to_add[ x.to_add.new_item_name ].value )}. Pick a different name.')
 ---
 id: other itemized job income value
 generic object: ALItemizedJob
 question: |
-  What do you get paid for ${ job_items_names.get(i, i) } in your job as a ${ x.source }?
+  How much do you get paid for ${ job_items_names.get(i, i) } in your job as a ${ x.source }?
 fields:
   - Amount: x.to_add[i].value
     datatype: currency
+  - How often do you get paid this amount?: x.to_add[i].times_per_year
+    input type: radio
+    code: |
+      times_per_year_list
+    datatype: integer
   - Do you have another source of income?: x.to_add.there_is_another
     datatype: yesnoradio
 ---
@@ -372,19 +378,97 @@ fields:
   - Who owns this?: x.owner
     required: False
 ---
-# UNIQUE CODE FOR ALIncomeList
+# UNIQUE FOR ALExpenses
 ---
-code: |
-  if income_sources.any_true():
-    for source in income_sources.true_values():
-      one_income = al_income_list.appendObject(source=source)
-      # Never put anything else in here
-  al_income_list.gathered = True
+generic object: ALExpenses
+id: expenses types
+question: |
+  What kind of expenses do you have?
+fields:
+  - no label: x.selected_types
+    datatype: checkboxes
+    code: |
+      expense_list_dict
 ---
+generic object: ALExpenses
+id: expense information
+question: |
+  How much do you spend on your ${ ordinal(i) } household expense?
+fields: 
+  - Type of expense: x[i].source
+    code: |
+      expense_list_dict
+  - Amount: x[i].value
+    datatype: currency
+  - How often do you pay this amount?: x[i].times_per_year
+    default: 12
+    code: |
+      times_per_year_list()
+---
+generic object: ALExpenses
+need:
+  - x[i].source
+  - x[i].display_name
+id: expense information, prefilled
+question: |
+  How much do you spend on ${ x[i].display_name.lower() }?
+subquestion: |
+  If you have more than one ${ x[i].display_name.lower() }
+  expense in your household, you'll have a chance to add another later on.
+fields:
+  - Amount: x[i].value
+    datatype: currency
+  - How often do you pay this amount?: x[i].times_per_year
+    default: 12
+    code: |
+      times_per_year_list
+---
+generic object: ALExpense
+need:
+  - x.source
+  - x.display_name
+id: single expense information prefilled
+question: |
+  How much do you spend on ${ x.display_name.lower() }?
+subquestion: |
+  If you have more than one ${ x.display_name.lower() }
+  expense in your household, you'll have a chance to add another later on.
+fields:
+  - Amount: x.value
+    datatype: currency
+  - How often do you pay this amount?: x.times_per_year
+    default: 12
+    code: |
+      times_per_year_list
+---
+generic object: ALExpenses
 code: |
-  for income in al_income_list.elements:
-    income.complete
-  get_alincome_list_item_values = True
+  x.selected_types
+  x.move_checks_to_list(expense_list_dict)
+  x.revisit = True
+  x.gathered = True
+---
+generic object: ALExpenses
+table: x.table
+rows: x
+columns:
+  - Type: |
+      x.display_name
+  - Amount per month: |
+      x.total(times_per_year=12)
+edit:
+  - type
+  - value
+---
+generic object: ALExpenses
+id: revisit expenses
+continue button field: x.revisit
+question: |
+  Edit expenses
+subquestion: |
+  ${ x.table }
+
+  ${ x.add_action() }
 ---
 # Why is this not being triggered
 id: which incomes

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -128,7 +128,7 @@ columns:
 edit:
   - exists
 ---
-generic object: ALExpenses 
+generic object: ALExpenseList 
 table: x.table
 rows: x
 columns:
@@ -490,9 +490,9 @@ fields:
   - Who owns this?: x.owner
     required: False
 ---
-# UNIQUE FOR ALExpenses
+# UNIQUE FOR ALExpenseList
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 id: expenses types
 question: |
   What kind of expenses do you have?
@@ -502,7 +502,7 @@ fields:
     code: |
       expense_terms_ordered
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 id: expense information
 question: |
   How much do you spend on your ${ ordinal(i) } household expense?
@@ -521,7 +521,7 @@ fields:
     code: |
       times_per_year_for_expenses
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 need:
   - x[i].source
   - x[i].display_name
@@ -557,13 +557,13 @@ fields:
     code: |
       times_per_year_list
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 code: |
   x.selected_types
   x.move_checks_to_list(selected_terms=expense_terms)
   x.moved = True
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 code: |
   x.moved
   for exp in x.elements:
@@ -571,7 +571,7 @@ code: |
   x.revisit = True
   x.gathered = True
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 table: x.table
 rows: x
 columns:
@@ -589,7 +589,7 @@ generic object: ALExpense
 code: |
   x.display_name = x.source
 ---
-generic object: ALExpenses
+generic object: ALExpenseList
 id: revisit expenses
 continue button field: x.revisit
 question: |

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -265,7 +265,7 @@ comment: |
 id: itemized job period
 generic object: ALItemizedJob
 question: |
-  Tell us about the hours when working as a ${ x.source }
+  What are the hours for the "${ x.source }" job?
 fields:
   - Is this a part time job: x.is_part_time
     datatype: yesnoradio
@@ -340,7 +340,7 @@ validation code: |
 id: other itemized job income value
 generic object: ALItemizedJob
 question: |
-  How much do you get paid for ${ job_items_names.get(i, i) } in your job as a ${ x.source }?
+  How much do you get paid in ${ job_items_names.get(i, i) } in your job as a ${ x.source }?
 fields:
   - Amount: x.to_add[i].value
     datatype: currency
@@ -510,7 +510,7 @@ fields:
   - Type of expense: x[i].source
     code: |
       expense_terms_ordered
-  - Describe your expense: x[i].source
+  - Other (explain): x[i].source
     show if:
       variable: x[i].source
       is: other
@@ -629,7 +629,7 @@ fields:
 id: regular job employer
 generic object: ALJob
 question: |
-  Who employs you as a ${ x.source }
+  Who employs you as a ${ x.source }?
 fields:
   - I am self-employed: x.is_self_employed
     datatype: yesno

--- a/docassemble/ALToolbox/data/questions/al_income_demo.yml
+++ b/docassemble/ALToolbox/data/questions/al_income_demo.yml
@@ -36,7 +36,7 @@ id: interview order
 mandatory: True
 code: |
   if to_run['ALItemizedJob'] or to_run['all']:
-    itemized_job.name = 'itemized taxi driver'
+    itemized_job.source = 'itemized taxi driver'
     itemized_job.complete
   
   if to_run['ALItemizedJobList'] or to_run['all']:
@@ -52,7 +52,7 @@ code: |
     get_alincome_list_item_values
   
   if to_run['ALJob'] or to_run['all']:
-    al_job.name = 'unitemized flight attendant'
+    al_job.source = 'unitemized flight attendant'
     al_job.complete
   
   if to_run['ALJobList'] or to_run['all']:
@@ -143,7 +143,6 @@ fields:
       #- asset_source_list: asset_source_list
       #- income_source_list: income_source_list
       #- non_wage_income_list: non_wage_income_list
-      #- expense_source_list: expense_source_list
 ---
 comment: |
   Notes on itemized job items:
@@ -288,7 +287,7 @@ subquestion: |
   Net | Monthly | ${ currency(al_job_list.net_total(times_per_year=12)) }
   
   One item value:[BR]
-  ${ [item for item in al_job_list.sources()][0] } base pay per year: ${ currency(al_job_list.net_total(source=[item for item in al_job_list.sources()][0])) }
+  ${ next(iter(al_job_list.sources()), None) } base pay per year: ${ currency(al_job_list.net_total(source=next(iter(al_job_list.sources()), None))) }
   
   % for one_job in al_job_list:
   #### ${ one_job.source }

--- a/docassemble/ALToolbox/data/questions/al_income_demo.yml
+++ b/docassemble/ALToolbox/data/questions/al_income_demo.yml
@@ -84,6 +84,20 @@ code: |
     al_income_list.there_are_any = income_sources.any_true
     al_income_list.target_number = len(income_sources.true_values())
 ---
+# UNIQUE CODE FOR ALIncomeList
+---
+code: |
+  if income_sources.any_true():
+    for source in income_sources.true_values():
+      one_income = al_income_list.appendObject(source=source)
+      # Never put anything else in here
+  al_income_list.gathered = True
+---
+code: |
+  for income in al_income_list.elements:
+    income.complete
+  get_alincome_list_item_values = True
+---
 id: which to test
 # TODO: Accumulate them all in one ALIncomeList at the end to test the ability of ALIncomeList to run its functions appropriately on all types of values (other than ALIncomeLists themselves)
 # TODO: Check these: Does ALAssetList cover all of ALIncomeList? Does ALAsset cover all of ALIncome?


### PR DESCRIPTION
* Made the ALPeriodicAmount class. Which is solely intended to house duplicate code between `ALExpense` and `ALIncome`. It straightens out the class hierarchy a bit, but it shouldn't be a concern for anyone but us, the module maintainers.
* adds the `move_checks_to_list`, to standardize the preferred way of gathering a big long list of potential expenses or incomes: by taking a checkboxes variable on a object and turning it into elements in a list with the `source` the same as the checkbox value
* made the ALJob class closer to the ALItemizedJob class. They shouldn't be different except for the Itemized part, so I made the employee an Individual
* Added the ALExpense and ALExpenses classes, as discussed previously (to avoid using the ALItemizedValueDict class)
* made slightly better names for the variables used for translation: `..._terms` and `..._terms_ordered`, instead of `list_dict`
* Moved over as many better default questions to `al_income.yml` from the Affidavit supplement when working on it.
  To be honest, there are still a lot of good default questions that we can't add, since you need to have access to the person containing the Job object. I suggest adding those questions to `AssemblyLine:ql_baseline.yml` for `users[0].jobs` and `ALIndividual.jobs` once this PR is in and we're content with the API
* went through all of `al_income_demo.yml` to fix some bugs and missing changes from this and #112.

Fixes #112 