### PR TITLE
Redefine the value of an item, not if it exists

### DIFF
--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -127,6 +127,7 @@ columns:
       '$0' if hasattr(row_item, 'exists') and not row_item.exists else currency(row_item.value)
 edit:
   - exists
+  - value
 ---
 generic object: ALExpenseList 
 table: x.table

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -117,6 +117,15 @@ subquestion: |
 
   ${ x.add_action() }
 ---
+generic object: ALIncomeList
+continue button field: x.revisit
+question: |
+  Edit incomes
+subquestion: |
+  ${ x.table }
+
+  ${ x.add_action() }
+---
 generic object: ALItemizedValueDict
 table: x.table
 rows: x


### PR DESCRIPTION
Asking only if an ItemizedValueDict entry exists won't ask the user the right questions; specifically letting them change the value of their dict. In this case, I've been setting up interviews to automatically define `exists` if asked for in this way, since usually I've been using `move_checks_to_list` to make objects already exist, yes / no. This means having `exists` and `value` re-edited doesn't ask two questions of the user.

Additionally, adds a default `revisit` question for the ALIncomeList object; otherwise edit buttons on review screens do nothing. 

Have tested with Affidavit Supplement, will likely merge without review, but feel free to give one post merge.