### PR TITLE
Make aria-controls point to a real element

### DIFF
--- a/docassemble/ALToolbox/misc.py
+++ b/docassemble/ALToolbox/misc.py
@@ -162,7 +162,7 @@ def collapse_template(
         classname = " " + classname.strip()
     the_id = re.sub(r"[^A-Za-z0-9]", "", template.instanceName)
     return f"""\
-<a class="collapsed" data-bs-toggle="collapse" href="#{ the_id }" role="button" aria-expanded="false" aria-controls="collapseExample"><span class="pdcaretopen">{ fa_icon(open_icon) }</span><span class="pdcaretclosed">{ fa_icon(closed_icon) }</span> { template.subject_as_html(trim=True) }</a>
+<a class="collapsed" data-bs-toggle="collapse" href="#{ the_id }" role="button" aria-expanded="false" aria-controls="{ the_id }"><span class="pdcaretopen">{ fa_icon(open_icon) }</span><span class="pdcaretclosed">{ fa_icon(closed_icon) }</span> { template.subject_as_html(trim=True) }</a>
 <div class="collapse" id="{ the_id }"><div class="card card-body pb-1{ classname }">{ template.content_as_html() }</div></div>\
 """
 


### PR DESCRIPTION
Was pointing to "collapseExample". Should now point to the correct ID of the collapsed element.