### PR TITLE
Add ALJobList revisit and table screens

### DIFF
--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -167,6 +167,15 @@ code: |
   x.to_subtract.gather()
   x.complete = True
 ---
+generic object: ALItemizedJob
+sets: x.employer.name.first
+code: |
+  if x.is_self_employed:
+    x.employer.name.first = "Self-employed"
+    x.employer.name.last = ""
+    x.employer.phone = ""
+    x.employer.address.address = ""
+---
 generic object: ALIncome
 code: |
   x.source
@@ -628,6 +637,15 @@ code: |
   x.source
   x.value
   x.complete = True
+---
+generic object: ALJob
+sets: x.employer.name.first
+code: |
+  if x.is_self_employed:
+    x.employer.name.first = "Self-employed"
+    x.employer.name.last = ""
+    x.employer.phone = ""
+    x.employer.address.address = ""
 ---
 id: regular job name
 generic object: ALJob

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -237,7 +237,7 @@ fields:
     show if:
       variable: x.is_self_employed
       is: False
-  - Employer's phone number: x.employer.phone_number
+  - Phone number: x.employer.phone_number
     required: False
     show if:
       variable: x.is_self_employed
@@ -700,7 +700,7 @@ fields:
     show if:
       variable: x.is_self_employed
       is: False
-  - Employer's phone: x.employer.phone
+  - Phone: x.employer.phone
     show if:
       variable: x.is_self_employed
       is: False

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -237,11 +237,20 @@ fields:
     show if:
       variable: x.is_self_employed
       is: False
-  - Phone number: x.employer.phone_number
+  - Employer's phone number: x.employer.phone_number
     required: False
     show if:
       variable: x.is_self_employed
       is: False
+---
+generic object: ALItemizedJob
+sets: x.employer.name.first
+code: |
+  if x.is_self_employed:
+    x.employer.name.first = "Self-employed"
+    x.employer.name.last = ""
+    x.employer.phone = ""
+    x.employer.address.address = ""
 ---
 id: itemized job line items
 generic object: ALItemizedJob
@@ -691,10 +700,19 @@ fields:
     show if:
       variable: x.is_self_employed
       is: False
-  - Phone: x.employer.phone
+  - Employer's phone: x.employer.phone
     show if:
       variable: x.is_self_employed
       is: False
+---
+generic object: ALJob
+sets: x.employer.name.first
+code: |
+  if x.is_self_employed:
+    x.employer.name.first = "Self-employed"
+    x.employer.name.last = ""
+    x.employer.phone = ""
+    x.employer.address.address = ""
 ---
 id: regular job value
 generic object: ALJob

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -743,11 +743,11 @@ columns:
   - Employer: |
       row_item.employer.name if hasattr(row_item.employer.name, "first") else ""
   - Annual Income: |
-      currency(row_item.net_total())
+      currency(row_item.gross_total())
 edit:
   - source
   - employer.name.first
-  - net
+  - value
 confirm: True
 ---
 # SHARED BY ALAsset AND ALAssetList

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -167,15 +167,6 @@ code: |
   x.to_subtract.gather()
   x.complete = True
 ---
-generic object: ALItemizedJob
-sets: x.employer.name.first
-code: |
-  if x.is_self_employed:
-    x.employer.name.first = "Self-employed"
-    x.employer.name.last = ""
-    x.employer.phone = ""
-    x.employer.address.address = ""
----
 generic object: ALIncome
 code: |
   x.source
@@ -646,15 +637,6 @@ code: |
   x.source
   x.value
   x.complete = True
----
-generic object: ALJob
-sets: x.employer.name.first
-code: |
-  if x.is_self_employed:
-    x.employer.name.first = "Self-employed"
-    x.employer.name.last = ""
-    x.employer.phone = ""
-    x.employer.address.address = ""
 ---
 id: regular job name
 generic object: ALJob

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -725,6 +725,31 @@ subquestion: |
 fields:
   - Job name: x[i].source
 ---
+generic object: ALJobList
+continue button field: x.revisit
+question: |
+  Edit jobs
+subquestion: |
+  ${ x.table }
+
+  ${ x.add_action() }
+---
+generic object: ALJobList
+table: x.table
+rows: x
+columns:
+  - Title: |
+      row_item.source
+  - Employer: |
+      row_item.employer.name if hasattr(row_item.employer.name, "first") else ""
+  - Annual Income: |
+      currency(row_item.net_total())
+edit:
+  - source
+  - employer.name.first
+  - net
+confirm: True
+---
 # SHARED BY ALAsset AND ALAssetList
 ---
 id: asset info


### PR DESCRIPTION
Currently being used for jobs of other household members in the Affidavit of Indigency supplement.

I did make a choice to ask for `net` in the ALJob upon edit. Might considering adjusting that API: how do / will most authors use ALJob? Do they need to know both net and gross, without knowing a specific deduction? Or given a specific job, will it always be gross or net? Might be a different PR.