### PR TITLE
Enforce people entering numbers for hours

### DIFF
--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -1028,6 +1028,14 @@ class ALItemizedJob(DAObject):
         else:
             frequency_to_use = self.times_per_year
 
+        # NOTE: fixes a bug that was present < 0.8.2
+        try :
+          hours_per_period = Decimal(self.hours_per_period)
+        except:
+          log(word("Your hours per period need to be just a single number, without words"), "danger")
+          delattr(self, "hours_per_period")
+          self.hours_per_period # Will cause another exception
+
         # Both the job and the item itself need to be hourly to be
         # calculated as hourly
         is_hourly = self.is_hourly and hasattr(item, "is_hourly") and item.is_hourly
@@ -1036,7 +1044,7 @@ class ALItemizedJob(DAObject):
         # Use the appropriate calculation
         if is_hourly:
             return (
-                value * Decimal(self.hours_per_period) * Decimal(frequency_to_use)
+                value * Decimal(hours_per_period) * Decimal(frequency_to_use)
             ) / Decimal(times_per_year)
         else:
             return (value * Decimal(frequency_to_use)) / Decimal(times_per_year)

--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -323,8 +323,11 @@ fields:
       times_per_year_list
     datatype: integer
   - How many hours are worked during that time?: x.hours_per_period
-    input type: number
+    datatype: number
     show if: x.is_hourly
+    validation messages:
+      number: |
+        Enter a number, like 40. If you don't know, enter your best guess.
 ---
 id: itemized job period
 generic object: Individual
@@ -344,8 +347,11 @@ fields:
       times_per_year_list
     datatype: integer
   - How many hours does ${ x } work during that time?: x.jobs[i].hours_per_period
-    input type: number
+    datatype: number
     show if: x.jobs[i].is_hourly
+    validation messages:
+      number: |
+        Enter a number, like 40. If you don't know, enter your best guess.
 ---
 id: itemized job period
 question: |
@@ -364,9 +370,11 @@ fields:
       times_per_year_list
     datatype: integer
   - How many hours do you work during that time?: users[0].jobs[i].hours_per_period
-    input type: number
+    datatype: number
     show if: users[0].jobs[i].is_hourly
-
+    validation messages:
+      number: |
+        Enter a number, like 40. If you don't know, enter your best guess.
 ---
 #id: other itemized job income name
 generic object: ALItemizedJob


### PR DESCRIPTION
We had `input type: number`, which doesn't exist, and so was doing nothing. Changed to `datatype: number`, and added validation messages that should show if the user enters something that's not a number.