### PR TITLE
Update display_name when category is changed

### DIFF
--- a/docassemble/ALToolbox/data/questions/al_income.yml
+++ b/docassemble/ALToolbox/data/questions/al_income.yml
@@ -536,6 +536,8 @@ fields:
     default: 12
     code: |
       times_per_year_for_expenses
+validation code: |
+  x[i].display_name = expense_terms.get(x[i].source, x[i].source)
 ---
 generic object: ALExpenseList
 need:

--- a/docassemble/ALToolbox/data/questions/al_income_demo.yml
+++ b/docassemble/ALToolbox/data/questions/al_income_demo.yml
@@ -34,7 +34,7 @@ objects:
   - al_value_list: ALSimpleValueList.using(
       complete_attribute='complete',
       ask_number=True)
-  - al_expense_list: ALExpenseList.using(auto_gather=False, complete_attribute="exists")
+  - al_expense_list: ALExpenseList.using(auto_gather=False)
 ---
 id: interview order
 mandatory: True


### PR DESCRIPTION
for ALExpenseList. Additionally, removes `complete_attribute="exists"` from the income demo expense list, as it's not needed, and can cause issues with review screens.

This is an upstream fix for an issue also fixed in https://github.com/SuffolkLITLab/docassemble-ALAffidavitOfIndigency/pull/49.