### PR TITLE
Add __all__ to all modules

### DIFF
--- a/docassemble/ALToolbox/Addup.py
+++ b/docassemble/ALToolbox/Addup.py
@@ -1,6 +1,8 @@
 # Add up numeric field values from a DAList object.
 from docassemble.base.util import DAValidationError, word
 
+__all__ = ["Addup"]
+
 
 class Addup:
     def __init__(self, listName, varName):

--- a/docassemble/ALToolbox/PhoneNumberDataType.py
+++ b/docassemble/ALToolbox/PhoneNumberDataType.py
@@ -1,6 +1,8 @@
 import re
 from docassemble.base.util import CustomDataType, DAValidationError
 
+__all__ = ["PhoneNumber"]
+
 
 class PhoneNumber(CustomDataType):
     name = "al_international_phone"

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -10,6 +10,8 @@ from docassemble.base.util import (
 from typing import Optional
 import re
 
+__all__ = ["ThreePartsDate", "BirthDate"]
+
 js_text = """\
 // This is an adaptation of Jonathan Pyle's datereplace.js
 

--- a/docassemble/ALToolbox/addenda.py
+++ b/docassemble/ALToolbox/addenda.py
@@ -1,3 +1,6 @@
+__all__ = ["myTable", "myTextList", "safe_json2"]
+
+
 # This function creates a Table list to be used in an addendum file. Currently it handles 'Thing' and 'Inidvidual' object type of DAList (special name attribute).
 class myTable:
     def __init__(self, tblData, tblTitle, tblHeader):

--- a/docassemble/ALToolbox/copy_button.py
+++ b/docassemble/ALToolbox/copy_button.py
@@ -1,5 +1,7 @@
 from docassemble.base.functions import word
 
+__all__ = ["copy_button_html"]
+
 
 # See GitHub issue https://github.com/SuffolkLITLab/docassemble-ALToolbox/issues/16
 def copy_button_html(

--- a/docassemble/ALToolbox/display_template.py
+++ b/docassemble/ALToolbox/display_template.py
@@ -2,6 +2,8 @@ import re
 from .copy_button import *
 from base64 import b64encode
 
+__all__ = ["display_template"]
+
 
 def display_template(
     template,


### PR DESCRIPTION
Making this change because a giant string js_text is getting loaded into the answers of every interview that uses ThreePartsDate or BirthDate right now; this should stop that. Also a good practice for every module.