### PR TITLE
Make collapse/display templates work in dark mode

### DIFF
--- a/docassemble/ALToolbox/data/static/collapse_template.css
+++ b/docassemble/ALToolbox/data/static/collapse_template.css
@@ -29,3 +29,12 @@
 .al_display_template a.collapsed .pdcaretclosed {
     display: inline;
 }
+
+/* An upstream fix for Bootstrap's lack of a dark/light mode neutral style.
+   See https://github.com/jhpyle/docassemble/pull/718 */
+[data-bs-theme=dark] .al_collapse_template .bg-light,
+[data-bs-theme=dark] .al_display_template .bg-light,
+[data-bs-theme=dark] .al_display_template.bg-light {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
+}


### PR DESCRIPTION
In dark mode, the display templates still have a light background, causing contrast issues with the text inside, and in general stands out far too much against the page background. This adds CSS to change the `bg-light` class for the collapse and display templates to the dark-mode colors when `data-bs-theme=dark`.

See https://github.com/jhpyle/docassemble/pull/718 for a discussion on a suggested fix for a similar issue, which resulted in the suggested workaround here.

An image of the dark mode display template without this PR:

![Screenshot from 2023-12-04 18-46-26](https://github.com/SuffolkLITLab/docassemble-ALToolbox/assets/6252212/d6cbd37f-8864-4b7b-86ac-b8185aafda72)


An image of the dark mode display template with this PR:

![Screenshot from 2023-12-04 18-45-29](https://github.com/SuffolkLITLab/docassemble-ALToolbox/assets/6252212/0c930edf-5628-4764-933a-f95fe7753063)
