### PR TITLE
Improve accessibility by associating `for` with `id` instead of `name`

### DIFF
--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -175,7 +175,7 @@ function create_month(date_id) {{
   */
   var $col = $('<div class="col col-month">');
   
-  var id = '_ignore_' + date_id + '_month';
+  let id = '_ignore_' + date_id + '_month';
   // '_ignore' in the name prevents the field from being submitted, avoiding a da error
   let name =  id;
   

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -179,7 +179,7 @@ function create_month(date_id) {{
   // '_ignore' in the name prevents the field from being submitted, avoiding a da error
   let name =  id;
   
-  var $label = $('<label for="' + id + '">{month}</label>');
+  let $label = $('<label for="' + id + '">{month}</label>');
   $col.append($label);
   
   // aria-describedby is ok to have, even when the date-part error is

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -130,16 +130,16 @@ function create_date_part({{type, date_id}}) {{
   * @returns undefined
   */
   var $col = $('<div class="col col-3 col-' + type + '">');
-  var id = date_id + '_' + type;
-  // '_ignore' prevents the field from being submitted, avoiding a da error
-  let name =  '_ignore_' + id;
+  var id = '_ignore_' + date_id + '_' + type;
+  // '_ignore' in the name prevents the field from being submitted, avoiding a da error
+  let name = id;
   
   // For python formatting, need to have {{day}} and {{year}}
   let $label = '';
   if (type === 'day') {{
-    $label = $('<label for="' + name + '">{day}</label>');
+    $label = $('<label for="' + id + '">{day}</label>');
   }} else {{
-    $label = $('<label for="' + name + '">{year}</label>');
+    $label = $('<label for="' + id + '">{year}</label>');
   }}
   $col.append($label);
   
@@ -175,11 +175,11 @@ function create_month(date_id) {{
   */
   var $col = $('<div class="col col-month">');
   
-  let id = date_id + '_month';
-  // '_ignore' prevents the field from being submitted, avoiding a da error
-  let name =  '_ignore_' + id;
+  var id = '_ignore_' + date_id + '_month';
+  // '_ignore' in the name prevents the field from being submitted, avoiding a da error
+  let name =  id;
   
-  let $label = $('<label for="' + name + '">{month}</label>');
+  var $label = $('<label for="' + id + '">{month}</label>');
   $col.append($label);
   
   // aria-describedby is ok to have, even when the date-part error is

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.ALToolbox',
       url='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/framework/altoolbox',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['holidays>=0.25', 'pandas>=2.0.3'],
+      install_requires=['holidays>=0.27.1', 'pandas>=2.0.3'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALToolbox/', package='docassemble.ALToolbox'),
      )


### PR DESCRIPTION
Closes #214. No rush on my part. I've tested it a bit myself to make sure basic behavior hasn't changed, though I don't think I have the tools I need to test the accessibility properly.

Not sure if we want to increment those package versions.