### PR TITLE
Make display_template look like a daterm

### DIFF
--- a/docassemble/ALToolbox/data/static/collapse_template.css
+++ b/docassemble/ALToolbox/data/static/collapse_template.css
@@ -5,6 +5,13 @@
   padding-bottom: 1rem;
 }
 
+.al_collapse_template a.al_toggle,
+.al_display_template a.al_toggle {
+  color: #3b842c; /* Same as daterm in Assembly Line */
+  text-decoration: dashed;
+  text-decoration-line: underline;
+}
+
 .al_collapse_template .collapse,
 .al_display_template .collapse {
     margin-bottom: 1rem;


### PR DESCRIPTION
They serve the same function (tap to get more information, and they don't navigate you away from the page), so it makes sense to brand them the same.

I'm not quite used to it yet, but I do think I will with a bit of time. Also have to keep in mind that most users aren't coming back again and again, they use our side a few times and don't return.

Fixes #208

![Screenshot from 2023-12-13 20-46-57](https://github.com/SuffolkLITLab/docassemble-ALToolbox/assets/6252212/bee3a2dc-4505-43c5-aee3-51f422d534c4)
