### PR TITLE
Change the escape button tag to a div, not a li

### DIFF
--- a/docassemble/ALToolbox/data/questions/escape_button.yml
+++ b/docassemble/ALToolbox/data/questions/escape_button.yml
@@ -8,7 +8,7 @@ objects:
 mandatory: True
 variable name: al_navigation_items["escape_button"]
 data: |
-  <li class="nav-item al_escape_nav"><a class="btn btn-danger al_escape" href="https://google.com">Escape</a></li>
+  <div class="nav-item al_escape_nav"><a class="btn btn-danger al_escape" href="https://google.com">Escape</a></div>
 ---
 default screen parts:
   navigation bar html: |

--- a/docassemble/ALToolbox/data/questions/escape_button_demo.yml
+++ b/docassemble/ALToolbox/data/questions/escape_button_demo.yml
@@ -12,13 +12,15 @@ subquestion: |
   If you would like to combine the "Escape" button with a custom link in the
   top navigation bar, you can do so by adding mandatory block like this:
 
-  ```
+  <pre>
+  <code>
   ---
   mandatory: True
   variable name: al_navigation_items["my_link"]
   data: |
-    <li class="nav-item"><a class="btn" href="https://google.com">My link</a></li>
-  ```
+    &lt;div class="nav-item"&gt;&lt;a class="btn" href="https://google.com"&gt;My link&lt;/a&gt;&lt;/div&gt;
+  </code>
+  </pre>
 
   And making sure that it runs on a line before you `include` the `escape_button.yml` file.
 


### PR DESCRIPTION
There wasn't a list to contain the escape button, so it shouldn't be a list item.

Also fixed some display issues on the demo page (three backticks for code blocks doesn't seem to work anymore).

Fix #196. 