### PR TITLE
Styles for display template

### DIFF
--- a/docassemble/ALToolbox/data/questions/display_template_demo.yml
+++ b/docassemble/ALToolbox/data/questions/display_template_demo.yml
@@ -26,7 +26,7 @@ subquestion: |
       - The default is to display the template with a scroll bar. This is helpful if your markdown template content is long.
       - If your markdown template has a subject line, it will be displayed automatically. The subject line is not required for this feature.
   1. **collapse** (default=False) 
-      - Change it to True to collapse/show youre template in order to save screen space. Template subject line is required.
+      - Change it to True to collapse/show you're template in order to save screen space. Template subject line is required.
       - This feature is similar to the **collapse_template()** function. It is combined into this function so that your can mix it with the other features. You can still call that function independently. See [collapse template demo](${interview_url(i=user_info().package + ":collapse_template_demo.yml")}).
   1. **copy** (default=False) 
       - It adds a copy button under the template for users to copy/share the template content.
@@ -55,7 +55,7 @@ subquestion: |
 id: collapse and scrollable examples
 continue button field: collapse_n_scrollable_examples
 question: |  
-  Collase and scrollable examples
+  Collapse and scrollable examples
 subquestion: |
   ##### Collapse only with a style
   ${ display_template(my_template1, scrollable=False, collapse=True, classname="my_color") }

--- a/docassemble/ALToolbox/display_template.py
+++ b/docassemble/ALToolbox/display_template.py
@@ -51,7 +51,7 @@ def display_template(
 
         # 2.1 If collapsible, add collapsible elements to the output
         if collapse:
-            return f'<div id="{container_id}" class="{container_classname}"><a class="collapsed" data-bs-toggle="collapse" href="#{contents_id}" role="button" aria-expanded="false" aria-controls="collapseExample"><span class="toggle-icon pdcaretopen"><i class="fas fa-caret-down"></i></span><span class="toggle-icon pdcaretclosed"><i class="fas fa-caret-right"></i></span><span class="subject">{template.subject_as_html(trim=True)}</span></a><div class="collapse" id="{contents_id}">{contents}</div></div>'
+            return f'<div id="{container_id}" class="{container_classname}"><a class="collapsed al_toggle" data-bs-toggle="collapse" href="#{contents_id}" role="button" aria-expanded="false" aria-controls="collapseExample"><span class="toggle-icon pdcaretopen"><i class="fas fa-caret-down"></i></span><span class="toggle-icon pdcaretclosed"><i class="fas fa-caret-right"></i></span><span class="subject">{template.subject_as_html(trim=True)}</span></a><div class="collapse" id="{contents_id}">{contents}</div></div>'
 
         # 2.2 If not collapsible, simply return output from copy_button_html()
         else:
@@ -65,7 +65,7 @@ def display_template(
     # 3. If not copiable, generate the whole output
     else:
         if collapse:
-            return f'<div id="{container_id}" class="{container_classname}"><a class="collapsed" data-bs-toggle="collapse" href="#{contents_id}" role="button" aria-expanded="false" aria-controls="collapseExample"><span class="toggle-icon pdcaretopen"><i class="fas fa-caret-down"></i></span><span class="toggle-icon pdcaretclosed"><i class="fas fa-caret-right"></i></span><span class="subject">{template.subject_as_html(trim=True)}</span></a><div class="collapse" id="{contents_id}"><div class="{scroll_class} card card-body {class_name} pb-1">{template.content_as_html()}</div></div></div>'
+            return f'<div id="{container_id}" class="{container_classname}"><a class="collapsed al_toggle" data-bs-toggle="collapse" href="#{contents_id}" role="button" aria-expanded="false" aria-controls="collapseExample"><span class="toggle-icon pdcaretopen"><i class="fas fa-caret-down"></i></span><span class="toggle-icon pdcaretclosed"><i class="fas fa-caret-right"></i></span><span class="subject">{template.subject_as_html(trim=True)}</span></a><div class="collapse" id="{contents_id}"><div class="{scroll_class} card card-body {class_name} pb-1">{template.content_as_html()}</div></div></div>'
 
         else:
             return f'<div id="{container_id}" class="{container_classname} {scroll_class} card card-body {class_name} pb-1" id="{contents_id}">{subject_html}<div>{template.content_as_html()}</div></div>'


### PR DESCRIPTION
Addition onto #208, which should have fixed this for collapsible display templates too, but didn't because they didn't use the same classes, for no reason that I can see: `al_toggle` wasn't used in style sheets before #232.

Have already tested, going to merge.

![Screenshot from 2023-12-14 13-41-40](https://github.com/SuffolkLITLab/docassemble-ALToolbox/assets/6252212/3ab6a1ce-d48e-4a23-8550-b7d8f8657bf6)
