### PR TITLE
If no openai key, don't try to make an OpenAI obj

### DIFF
--- a/docassemble/ALToolbox/llms.py
+++ b/docassemble/ALToolbox/llms.py
@@ -27,9 +27,11 @@ __all__ = [
 
 if os.getenv("OPENAI_API_KEY"):
     client: Optional[OpenAI] = OpenAI()
-else:
+elif get_config("open ai"):
     api_key = get_config("open ai", {}).get("key")
     client = OpenAI(api_key=api_key)
+else:
+    client = None
 
 always_reserved_names = set(
     docassemble.base.util.__all__


### PR DESCRIPTION
Avoids errors in logs like:

```
Import of docassemble.ALToolbox.llms failed.
OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```