### PR TITLE
Fixed bug that required alMax

### DIFF
--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -510,7 +510,12 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   // Non-MVP. Make an issue.
   // Replace '-' in case it's an ISO date format, (our recommended format).
   // JS doesn't play nicely with ISO format.
-  var min_date = new Date(get_$original_date(field).attr('data-alMin').replace(/-/g, '/'));
+  var min_attr = get_$original_date(field).attr('data-alMin');
+  if (!min_attr) {{
+    // Validation should always succeed if no minimum given
+    return true;
+  }}
+  var min_date = new Date(min_attr.replace(/-/g, '/'));
   
   // Avoid usinig `params`, which could be in many different formats.
   // Just get date data from the actual fields
@@ -538,7 +543,12 @@ $.validator.addMethod('alMax', function(value, field, params) {{
   }}
 
   // TODO: Catch invalid alMax attr values for devs? Log in console? Make post MVP issue
-  let max_date = new Date(get_$original_date(field).attr('data-alMax').replace(/-/g, '/'));
+  let max_attr = get_$original_date(field).attr('data-alMax');
+  if (!max_attr) {{
+    // Validation should always succeed if no minimum given
+    return true;
+  }}
+  let max_date = new Date(max_attr.replace(/-/g, '/'));
   if ( isNaN(max_date) && is_birthdate(field)) {{
     max_date = new Date();
   }}


### PR DESCRIPTION
https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/241 introduced a slight regression that assumed that both `alMax` and `alMin` would be present. If they weren't, the JS on the page would stop running, resulting in error messages not going away even when corrected.

Tested on my local server and it fixed the problem, removing the errors in my browser console.

Fix #244