### PR TITLE
Check isNaN on alMax & use today as birthdate max

### DIFF
--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -512,7 +512,7 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   // JS doesn't play nicely with ISO format.
   let min_attr = get_$original_date(field).attr('data-alMin') || "";
   let min_date = new Date(min_attr.replace(/-/g, '/'));
-  if (isNaN(min_attr)) {{
+  if (isNaN(min_date)) {{
     if (min_attr !== "") {{
       console.log(`The alMin attribute (${{ min_attr }}) isn't a valid date!`);
     }}
@@ -529,7 +529,8 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   
 }}, function alMinMessage (validity, field) {{
   /** Returns the string of the invalidation message. */
-  let min_date = new Date(get_$original_date(field).attr('data-alMin').replace(/-/g, '/'));
+  let min_attr = get_$original_date(field).attr('data-alMin') || "";
+  let min_date = new Date(min_attr.replace(/-/g, '/'));
   let locale_long_date = min_date.toLocaleDateString(undefined, {{ day: '2-digit', month: 'long', year: 'numeric' }});
   return (
     get_$original_date(field).attr('data-alMinMessage')
@@ -547,8 +548,8 @@ $.validator.addMethod('alMax', function(value, field, params) {{
 
   // TODO: Catch invalid alMax attr values for devs? Log in console? Make post MVP issue
   let max_attr = get_$original_date(field).attr('data-alMax') || "";
-  let max_date = new Date(max_attr);
-  if (isNaN(max_attr)) {{
+  let max_date = new Date(max_attr.replace(/-/g, '/'));
+  if (isNaN(max_date)) {{
     if (max_attr !== "") {{
       console.log(`The alMax attribute (${{ max_attr }}) isn't a valid date!`);
     }}
@@ -570,11 +571,12 @@ $.validator.addMethod('alMax', function(value, field, params) {{
   
 }}, function alMaxMessage (validity, field) {{
   /** Returns the string of the invalidation message. */
-  let max_date = new Date(get_$original_date(field).attr('data-alMax').replace(/-/g, '/'));
+  let max_attr = get_$original_date(field).attr('data-alMax') || "";
+  let max_date = new Date(max_attr.replace(/-/g, '/'));
   let locale_long_datetime = max_date.toLocaleDateString(undefined, {{ day: '2-digit', month: 'long', year: 'numeric' }})
   let default_MaxMessage = `The date needs to be on or before ${{ locale_long_datetime }}.`;
   // Birthdays have a different default max message
-  if (!get_$original_date(field).attr('data-alMax') && is_birthdate(field)) {{
+  if (is_birthdate(field) && isNaN(max_date)) {{
     default_MaxMessage = 'A <strong>birthdate</strong> must be in the past.';
   }}
   

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -528,7 +528,8 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   return date_input >= min_date;
   
 }}, function alMinMessage (validity, field) {{
-  /** Returns the string of the invalidation message. */
+  /** Returns the string of the invalidation message, or blank string for
+   * safety and consistency with alMaxMessage. */
   let min_attr = get_$original_date(field).attr('data-alMin') || "";
   let min_date = new Date(min_attr.replace(/-/g, '/'));
   let locale_long_date = min_date.toLocaleDateString(undefined, {{ day: '2-digit', month: 'long', year: 'numeric' }});

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -510,14 +510,14 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   // Non-MVP. Make an issue.
   // Replace '-' in case it's an ISO date format, (our recommended format).
   // JS doesn't play nicely with ISO format.
-  var min_attr = get_$original_date(field).attr('data-alMin');
-  if (!min_attr) {{
-    // Validation should always succeed if no minimum given
+  let min_attr = get_$original_date(field).attr('data-alMin') || "";
+  let min_date = new Date(min_attr.replace(/-/g, '/'));
+  if (isNaN(min_attr)) {{
+    // Validation should always succeed if no or bad minimum given
     return true;
   }}
-  var min_date = new Date(min_attr.replace(/-/g, '/'));
   
-  // Avoid usinig `params`, which could be in many different formats.
+  // Avoid using `params`, which could be in many different formats.
   // Just get date data from the actual fields
   var data = get_date_data(field);
   var date_input = new Date(data.year + '/' + data.month + '/' + data.day);
@@ -543,17 +543,19 @@ $.validator.addMethod('alMax', function(value, field, params) {{
   }}
 
   // TODO: Catch invalid alMax attr values for devs? Log in console? Make post MVP issue
-  let max_attr = get_$original_date(field).attr('data-alMax');
-  if (!max_attr) {{
-    // Validation should always succeed if no minimum given
-    return true;
-  }}
-  let max_date = new Date(max_attr.replace(/-/g, '/'));
-  if ( isNaN(max_date) && is_birthdate(field)) {{
-    max_date = new Date();
+  let max_attr = get_$original_date(field).attr('data-alMax') || "";
+  let max_date = new Date(max_attr);
+  if (isNaN(max_attr)) {{
+    if (!is_birthdate(field)) {{
+      // Validation should always succeed if no or bad max given on normal dates
+      return true;
+    }} else {{
+      // if birthdate and no or bad max given, assume today is the max date
+      max_date = new Date();
+    }}
   }}
   
-  // Avoid usinig `params`, which could be in many different formats.
+  // Avoid using `params`, which could be in many different formats.
   // Just get date data from the actual fields
   var data = get_date_data(field);
   var date_input = new Date(data.year + '/' + data.month + '/' + data.day);

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -513,9 +513,9 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   let min_attr = get_$original_date(field).attr('data-alMin') || "";
   let min_date = new Date(min_attr.replace(/-/g, '/'));
   if (isNaN(min_attr)) {{
-    if (min_attr !== "") {
-      console.log(`The alMin attribute (${ min_attr }) isn't a valid date!`);
-    }
+    if (min_attr !== "") {{
+      console.log(`The alMin attribute (${{ min_attr }}) isn't a valid date!`);
+    }}
     // Validation should always succeed if no or bad minimum given
     return true;
   }}
@@ -549,9 +549,9 @@ $.validator.addMethod('alMax', function(value, field, params) {{
   let max_attr = get_$original_date(field).attr('data-alMax') || "";
   let max_date = new Date(max_attr);
   if (isNaN(max_attr)) {{
-    if (max_attr !== "") {
-      console.log(`The alMax attribute (${ max_attr }) isn't a valid date!`);
-    }
+    if (max_attr !== "") {{
+      console.log(`The alMax attribute (${{ max_attr }}) isn't a valid date!`);
+    }}
     if (!is_birthdate(field)) {{
       // Validation should always succeed if no or bad max given on normal dates
       return true;

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -513,6 +513,9 @@ $.validator.addMethod('alMin', function(value, field, params) {{
   let min_attr = get_$original_date(field).attr('data-alMin') || "";
   let min_date = new Date(min_attr.replace(/-/g, '/'));
   if (isNaN(min_attr)) {{
+    if (min_attr !== "") {
+      console.log(`The alMin attribute (${ min_attr }) isn't a valid date!`);
+    }
     // Validation should always succeed if no or bad minimum given
     return true;
   }}
@@ -546,6 +549,9 @@ $.validator.addMethod('alMax', function(value, field, params) {{
   let max_attr = get_$original_date(field).attr('data-alMax') || "";
   let max_date = new Date(max_attr);
   if (isNaN(max_attr)) {{
+    if (max_attr !== "") {
+      console.log(`The alMax attribute (${ max_attr }) isn't a valid date!`);
+    }
     if (!is_birthdate(field)) {{
       // Validation should always succeed if no or bad max given on normal dates
       return true;


### PR DESCRIPTION
Finish the code done in https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/245.

@plocket, is this the direction we want to take? I tried a version using `if/else`s like you suggested in https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/245#discussion_r1453649722, but there are more cases than you mentioned there. It was much harder to read IMO, so I didn't continue that.

This does treat invalid alMax / alMin dates as nothing instead of as a NaN Date, which will always be false when compared to other dates with `<=` and `>=`. I think means user's wouldn't be able to submit? (part of the testing I need to still do). It's a behavior change, but probably the safest one?

Tested with:

* [x] no max date
* [x] invalid max date
* [x] valid max date
* [x] no min date
* [x] invalid min date
* [x] valid min date
* [x] no max birthdate
* [x] invalid max birthdate
* [x] valid max birthdate (before and after today)