### PR TITLE
Make moderation optional in llms.py, remove references to gpt-4-turbo-1106-preview as json mode is now general release

### DIFF
--- a/docassemble/ALToolbox/business_days.py
+++ b/docassemble/ALToolbox/business_days.py
@@ -36,11 +36,14 @@ def standard_holidays(
     add_holidays should be a dictionary from dates ("12-15") to the name of the holiday.
 
     Returns a dictionary like-object that you can treat like:
+
+    ```
     {
         "2021-01-01": "New Year's Day",
         ...
         "2021-12-25": "Christmas Day",
     }
+    ```
 
     In place of a string, the object that is returned can also be treated as though
     the keys are datetime.date objects.


### PR DESCRIPTION
Fix #254

For speed and efficiency, automators may want to skip the moderation endpoint that is usually called by the chat_completion function. All queries are moderated by default as a best practice to avoid the account being flagged, but if you **know** the query is safe, this change allows you to skip it.

Also removed some logging statements that could have slowed down performance.