### PR TITLE
Add missing `"` when calling `fa_icon` with `color_css`

### DIFF
--- a/docassemble/ALToolbox/misc.py
+++ b/docassemble/ALToolbox/misc.py
@@ -115,7 +115,7 @@ def fa_icon(
     if not size and not color and not color_css:
         return ":" + icon + ":"  # Default to letting Docassemble handle it
     if color_css:
-        return f'<i class="{fa_class} fa-{icon}{size_str} style="color:{color_css};" aria-hidden="{str(aria_hidden).lower()}"></i>'
+        return f'<i class="{fa_class} fa-{icon}{size_str}" style="color:{color_css};" aria-hidden="{str(aria_hidden).lower()}"></i>'
     if color:
         return (
             f'<i class="{fa_class} fa-{icon}{size_str}" '


### PR DESCRIPTION
Without it, it's invalid HTML, that causes an error with Font awesome it loads. Prevents that icon and the icons later on the page from loading.