### PR TITLE
Update parameters to match behavior of gpt-5; still backwards compatible

### DIFF
--- a/docassemble/ALToolbox/llms.py
+++ b/docassemble/ALToolbox/llms.py
@@ -237,17 +237,17 @@ def chat_completion(
     is_thinking_model = any(
         model.startswith(prefix) for prefix in ["o1", "o3", "gpt-5"]
     )
-    
+
     completion_params = {
         "model": model,
         "messages": messages,
         "response_format": {"type": "json_object"} if json_mode else None,  # type: ignore
         "max_completion_tokens": max_output_tokens,
     }
-    
+
     if not is_thinking_model:
         completion_params["temperature"] = temperature
-    
+
     response = openai_client.chat.completions.create(**completion_params)
 
     # check finish reason


### PR DESCRIPTION
Thinking models (which we weren't ever using before) do not support temperature, and they require the max_completion_tokens parameter instead of max_tokens.

max_completion_tokens is backwards compatible, so we can just always use that. But we need to conditionally stop sending temperature when using gpt-5 family or other thinking models.