### PR TITLE
Add markdown code blocks to examples in docstrings

### DIFF
--- a/docassemble/ALToolbox/Addup.py
+++ b/docassemble/ALToolbox/Addup.py
@@ -44,8 +44,10 @@ class Addup:
                 or contained no numeric values.
 
         Example:
+        ```python
             >>> addup = Addup(income_list, "monthly_amount")
             >>> # Returns sum of monthly_amount fields from all items in income_list
+        ```
         """
         self.sum = 0
         for w in listName:

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -909,12 +909,14 @@ def check_empty_parts(item: str, default_msg="{} is not a valid date") -> Option
         a localized error message indicating which parts need to be entered.
 
     Example:
+    ```python
         >>> check_empty_parts("12//2023")
         "Enter a day"
         >>> check_empty_parts("//")
         "Enter a month, a day, and a year"
         >>> check_empty_parts("12/25/2023")
         None
+    ```
     """
     # This only handles US dates. How do we use a locale-specific date?
     parts = item.split("/")

--- a/docassemble/ALToolbox/addenda.py
+++ b/docassemble/ALToolbox/addenda.py
@@ -101,8 +101,10 @@ class myTextList:
             and self.txtList to contain addendum data if truncation occurred.
 
         Example:
+        ```python
             >>> text_handler = myTextList("Very long text...", 100, "Description")
             >>> # If text > 100 chars, text_cutoff will end with " (See Addendum.)"
+        ```
         """
         # 1. Adjust limit
         sLimit = (
@@ -152,10 +154,12 @@ def safe_json2(the_object, level=0, is_key=False) -> Any:
         limit is exceeded.
 
     Example:
+    ```python
         >>> import datetime
         >>> obj = {"date": datetime.datetime(2023, 12, 25)}
         >>> safe_json2(obj)
         {"date": "12/25/2023"}
+    ```
     """
     if level > 20:
         return "None" if is_key else None
@@ -236,10 +240,12 @@ def type_name(the_object) -> str:
         str: The class name of the object, or the full type string if parsing fails.
 
     Example:
+    ```python
         >>> type_name("hello")
         'str'
         >>> type_name([1, 2, 3])
         'list'
+    ```
     """
     name = str(type(the_object))
     m = re.search(r"\'(.*)\'", name)

--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -103,10 +103,12 @@ def times_per_year(
         description if not found in the list.
 
     Examples:
+    ```python
         >>> times_per_year([(12, "Monthly"), (1, "Annually")], 12)
         'monthly'
         >>> times_per_year([(12, "Monthly")], 5)
         'Five times per year'
+    ```
     """
     try:
         for row in times_per_year_list:
@@ -141,10 +143,12 @@ def recent_years(
         List[int]: List of years in the specified order.
 
     Examples:
+    ```python
         >>> recent_years(past=3, future=1)  # if current year is 2023
         [2024, 2023, 2022, 2021]
         >>> recent_years(past=2, order="ascending", future=0)
         [2022, 2023]
+    ```
     """
     now = datetime.datetime.now()
     if order == "ascending":
@@ -192,11 +196,13 @@ class ALPeriodicAmount(DAObject):
             Decimal: The calculated income amount for the specified frequency.
 
         Examples:
+        ```python
             >>> income = ALPeriodicAmount(value=1000, times_per_year=12)  # $1000/month
             >>> income.total(1)  # Annual total
             Decimal('12000')
             >>> income.total(12)  # Monthly total
             Decimal('1000')
+        ```
         """
         val = _currency_float_to_decimal(self.value)
         return (val * Decimal(self.times_per_year)) / Decimal(times_per_year)
@@ -353,6 +359,7 @@ class ALIncomeList(DAList):
             Set[str]: A set containing all unique source names from items in the list.
 
         Examples:
+        ```python
             >>> income_list = ALIncomeList([
             ...     ALIncome(source="wages"),
             ...     ALIncome(source="tips"),
@@ -360,6 +367,7 @@ class ALIncomeList(DAList):
             ... ])
             >>> income_list.sources()
             {'wages', 'tips'}
+        ```
         """
         sources = set()
         for item in self.elements:
@@ -385,6 +393,7 @@ class ALIncomeList(DAList):
             ALIncomeList: A new ALIncomeList containing only items with matching sources.
 
         Examples:
+        ```python
             >>> income_list = ALIncomeList([
             ...     ALIncome(source="wages", value=1000),
             ...     ALIncome(source="tips", value=200),
@@ -393,6 +402,7 @@ class ALIncomeList(DAList):
             >>> wages_only = income_list.matches("wages")
             >>> len(wages_only)
             2
+        ```
         """
         # Always make sure we're working with a set
         satifies_sources = _source_to_callable(source, exclude_source)
@@ -431,11 +441,13 @@ class ALIncomeList(DAList):
             Decimal: The total income amount for the specified frequency and filters.
 
         Examples:
+        ```python
             >>> income_list = ALIncomeList([wages_income, tips_income])
             >>> income_list.total(times_per_year=12)  # Monthly total
             Decimal('5000.00')
             >>> income_list.total(source="wages")  # Annual wages only
             Decimal('60000.00')
+        ```
         """
         self._trigger_gather()
         result: Decimal = Decimal(0)
@@ -1027,11 +1039,13 @@ class ALVehicle(ALAsset):
             str: A formatted string combining year, make, and model of the vehicle.
 
         Examples:
+        ```python
             >>> vehicle = ALVehicle(year=2020, make="Toyota", model="Camry")
             >>> vehicle.year_make_model()
             '2020 / Toyota / Camry'
             >>> vehicle.year_make_model(separator=", ")
             '2020, Toyota, Camry'
+        ```
         """
         return separator.join(map(str, [self.year, self.make, self.model]))
 
@@ -1202,12 +1216,14 @@ class ALItemizedValue(DAObject):
             or has no value.
 
         Examples:
+        ```python
             >>> item = ALItemizedValue(value=1500, exists=True)
             >>> item.total()
             Decimal('1500')
             >>> item_disabled = ALItemizedValue(exists=False)
             >>> item_disabled.total()
             Decimal('0')
+        ```
         """
         # If an item's value doesn't exist, use a value of 0
         # TODO: is this behavior correct, or should it force gathering the value?
@@ -1285,11 +1301,13 @@ class ALItemizedValueDict(DAOrderedDict):
             Decimal: The sum of all existing item values in the dictionary.
 
         Examples:
+        ```python
             >>> value_dict = ALItemizedValueDict()
             >>> value_dict['wages'] = ALItemizedValue(value=1000, exists=True)
             >>> value_dict['bonus'] = ALItemizedValue(value=500, exists=False)
             >>> value_dict.total()
             Decimal('1000')  # Only includes wages, not bonus
+        ```
         """
         val = Decimal(0)
         for key, value in self.elements.items():

--- a/docassemble/ALToolbox/copy_button.py
+++ b/docassemble/ALToolbox/copy_button.py
@@ -48,8 +48,10 @@ def copy_button_html(
         str: Complete HTML string containing the copy button and associated elements.
 
     Example:
+    ```python
         >>> copy_button_html("Hello World", text_before="Message:", label="Copy Message")
         '<div class="al_copy">...<button class="btn btn-secondary al_copy_button">...</div>'
+    ```
     """
 
     button_str = '<div class="al_copy">\n'

--- a/docassemble/ALToolbox/display_template.py
+++ b/docassemble/ALToolbox/display_template.py
@@ -39,8 +39,10 @@ def display_template(
         display options.
 
     Example:
+    ```python
         >>> display_template(my_template, scrollable=True, collapse=True)
         '<div id="..." class="al_display_template">...</div>'
+    ```
     """
     # 1. Initialize
     if scrollable:

--- a/docassemble/ALToolbox/misc.py
+++ b/docassemble/ALToolbox/misc.py
@@ -79,10 +79,12 @@ def thousands(num: Union[float, str, Decimal], show_decimals=False) -> str:
         with 2 decimal places.
 
     Example:
+    ```python
         >>> thousands(1234.56)
         '1,234'
         >>> thousands(1234.56, show_decimals=True)
         '1,234.56'
+    ```
     """
     try:
         if show_decimals:
@@ -107,8 +109,10 @@ def tel(phone_number) -> str:
         str: HTML anchor tag with tel: link containing the phone number.
 
     Example:
+    ```python
         >>> tel("555-123-4567")
         '<a href="tel:555-123-4567">555-123-4567</a>'
+    ```
     """
     return '<a href="tel:' + str(phone_number) + '">' + str(phone_number) + "</a>"
 
@@ -177,10 +181,12 @@ def space(var_name: str, prefix=" ", suffix="") -> str:
         and has a value, otherwise an empty string.
 
     Example:
+    ```python
         >>> space("user_middle_name", prefix=" ", suffix="")
         " John"  # if user_middle_name is defined as "John"
         >>> space("undefined_var")
         ""  # if variable is not defined
+    ```
     """
     if (
         var_name
@@ -216,12 +222,14 @@ def yes_no_unknown(
         condition is None, or the placeholder value if condition is False.
 
     Example:
+    ```python
         >>> yes_no_unknown("user_answer", True, "Unknown", 0)
         # Returns value of user_answer variable
         >>> yes_no_unknown("user_answer", None, "Unknown", 0)
         "Unknown"
         >>> yes_no_unknown("user_answer", False, "Unknown", 0)
         0
+    ```
     """
     if condition:
         return value(var_name)
@@ -245,12 +253,14 @@ def number_to_letter(n: Optional[int]) -> str:
         str: The letter representation of the number using Excel-style column naming.
 
     Example:
+    ```python
         >>> number_to_letter(1)
         'A'
         >>> number_to_letter(26)
         'Z'
         >>> number_to_letter(27)
         'AA'
+    ```
     """
     string = ""
     if n is None:
@@ -293,8 +303,10 @@ def collapse_template(
         string if template has no content.
 
     Example:
+    ```python
         >>> collapse_template(my_template, classname="bg-primary", collapsed=False)
         '<div id="..." class="al_collapse_template">...</div>'
+    ```
     """
     if not template.subject_as_html(trim=True) and not template.content_as_html():
         return ""
@@ -339,8 +351,10 @@ def tabbed_templates_html(tab_group_name: str, *pargs) -> str:
         panels.
 
     Example:
+    ```python
         >>> tabbed_templates_html("my_tabs", template1, template2, template3)
         '<ul class="nav nav-tabs" id="my_tabs">...</ul><div class="tab-content">...</div>'
+    ```
     """
     if isinstance(tab_group_name, str):
         tab_group_name = space_to_underscore(tab_group_name)
@@ -446,8 +460,10 @@ def sum_if_defined(*pargs) -> Union[int, float, Decimal]:
         are treated as 0 (skipped).
 
     Example:
+    ```python
         >>> sum_if_defined("income1", "income2", "income3")
         # Returns sum of defined income variables, skipping any undefined ones
+    ```
     """
     total = 0
     for source in pargs:
@@ -472,9 +488,11 @@ def add_records(obj, labels) -> Any:
         The populated obj (DAList) with interview records added.
 
     Example:
+    ```python
         >>> interviews = {"intake": ["Intake Interview", "intake.yml"]}
         >>> add_records(my_list, interviews)
         # my_list[0].name = "intake", description = "Intake Interview", etc.
+    ```
     """
     index = 0
     for key, val in labels.items():
@@ -507,10 +525,12 @@ def output_checkbox(
         The checked_value if value_to_check is True, otherwise unchecked_value.
 
     Example:
+    ```python
         >>> output_checkbox(True)
         '[X]'
         >>> output_checkbox(False, checked_value="YES", unchecked_value="NO")
         'NO'
+    ```
     """
     if value_to_check:
         return checked_value
@@ -533,10 +553,12 @@ def nice_county_name(address: Address) -> str:
         the address has no county attribute.
 
     Example:
+    ```python
         >>> nice_county_name(address_with_county)
         'Suffolk'  # if address.county was "Suffolk County"
         >>> nice_county_name(address_without_county)
         ''
+    ```
     """
     if not hasattr(address, "county"):
         return ""
@@ -694,9 +716,11 @@ def include_a_year(text: str, field: Optional[str] = None) -> bool:
         DAValidationError: If no valid year pattern is found in the text.
 
     Example:
+    ```python
         >>> include_a_year("Born in 1985")
         True
         >>> include_a_year("Born long ago")  # raises DAValidationError
+    ```
     """
     # Match a 4-digit sequence
     if re.search(r"\b(18|19|20|21)\d{2}\b", text):
@@ -773,13 +797,16 @@ def format_date_if_defined(
     Returns:
         A formatted date string if `date_object_name` is defined, otherwise an empty string.
 
-    Example:
-
+    Examples:
+    ```python
         >>> format_date_if_defined("users[0].birthdate", format='yyyy-MM-dd')
+    ```
 
         Returns a formatted date string if "users[0].birthdate" is defined, otherwise returns an empty string.
 
+    ```python
         >>> format_date_if_defined("users[0].birthdate", default="No date provided", format='yyyy-MM-dd ')
+    ```
 
         Returns a formatted date string followed by one space if "users[0].birthdate" is defined, otherwise returns "No date provided". (Note space is added to the format="..." parameter)
     """

--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -43,12 +43,14 @@ def save_input_data(
         - Data is stored with a random 32-character alphanumeric key
 
     Example:
+    ```python
         >>> survey_data = {
         ...     "age": 25,
         ...     "income": 50000.0,
         ...     "interests": my_checkbox_dict
         ... }
         >>> save_input_data("User Survey", survey_data, ["survey", "demographics"])
+    ```
     """
     type_dict: Dict[str, str] = {}
     field_dict: Dict[str, Any] = {}


### PR DESCRIPTION
Without them, there's no line breaking in the documentation; with them, the code is displayed as it is displayed in the code file itself, indentation and newlines included, so it's much easier to read.

Currently: 

<img width="894" height="165" alt="Screenshot 2025-12-05 at 11 28 25 AM" src="https://github.com/user-attachments/assets/3ef9975a-bc42-4e6d-910c-fa7c834be87d" />

With this patch:

<img width="796" height="214" alt="Screenshot 2025-12-05 at 11 34 11 AM" src="https://github.com/user-attachments/assets/d60541b8-4b09-46ec-aa40-5d7b4c312511" />
