### PR TITLE
Trigger 'change' event when custom ThreePartsDate fields change

### DIFF
--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -307,7 +307,10 @@ function update_original_date($al_date) {{
   
   let val_date = US_date;
   
-  get_$original_date($al_date).val(val_date);
+  $original_date = get_$original_date($al_date)
+  $original_date.val(val_date);
+  $original_date.trigger(`change`);
+  
 }};  // Ends update_original_date()
   
   


### PR DESCRIPTION
This will make sure that `show if` and such respond to changes of the date fields.

Obviously it's hard to test this on our shared server. I tested this change locally and it worked, but my local setup doesn't have GitHub connected yet. I'm hopeful it's working.

Edit: Example use
```
---
question: |
  Hide if
fields:
  - note: |
      The `BirthDate` datatype is like `ThreePartsDate`, but it stops users entering dates in the future.
    hide if:
      variable: date_of_birth
      is: ''
  - Birth date (today is valid): date_of_birth
    datatype: BirthDate
---
```