### PR TITLE
Associate the ThreePartDate inputs with the original label

### DIFF
--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -51,6 +51,17 @@ js_text = """\
 try {{
 
 $(document).on('daPageLoad', function(){{
+  // Replace the div with a fieldset for accessibility.
+  $('div.da-field-container-datatype-ThreePartsDate').each(function() {{
+    var $container = $(this);
+    var $fieldset = $('<fieldset class="da-container da-form-group row da-field-container da-field-container-datatype-ThreePartsDate">');
+    for (let c of $container.children()) {{
+      $fieldset.append($(c).detach());
+    }}
+    $container.after($fieldset);
+    $container.remove();
+  }});
+
   $('input[type="ThreePartsDate"]').each(function(){{
     let $al_date = replace_date(this);
     set_up_validation($al_date);
@@ -71,10 +82,20 @@ function replace_date(original_date) {{
   $original_date.attr('type', 'hidden');
   $original_date.attr('aria-hidden', 'true');
   
+  var date_id = $original_date.attr('id');
+
+  // Add a legend for accessibily (off the page with CSS), keeping the original date label for better visual display.
+  $('label[for="' + date_id + '"]').each(function() {{
+    var $label = $(this);
+    var $legend = $('<legend class="col-md-4 col-form-label da-form-label datext-right">' + $label.text() + '</legend>');
+    $label.after($legend);
+    $label.attr('aria-hidden', 'true');
+    $label.attr('old-for', $label.attr('for'));
+    $label.removeAttr('for');
+  }});
+
   var $al_date = $('<div class="al_three_parts_date form-row row">');
   $original_date.before($al_date);
-
-  var date_id = $original_date.attr('id');
   
   // -- Construct the input components --
   let display_names = new Intl.DisplayNames(document.documentElement.lang, {{ type: "dateTimeField" }});

--- a/docassemble/ALToolbox/ThreePartsDate.py
+++ b/docassemble/ALToolbox/ThreePartsDate.py
@@ -53,10 +53,10 @@ try {{
 $(document).on('daPageLoad', function(){{
   // Replace the div with a fieldset for accessibility.
   $('div.da-field-container-datatype-ThreePartsDate').each(function() {{
-    var $container = $(this);
-    var $fieldset = $('<fieldset class="da-container da-form-group row da-field-container da-field-container-datatype-ThreePartsDate">');
-    for (let c of $container.children()) {{
-      $fieldset.append($(c).detach());
+    const $container = $(this);
+    const $fieldset = $(`<fieldset>`).addClass($container.attr(`class`));
+    for (let child of $container.children()) {{
+      $fieldset.append($(child).detach());
     }}
     $container.after($fieldset);
     $container.remove();

--- a/docassemble/ALToolbox/data/static/al_three_parts_date.css
+++ b/docassemble/ALToolbox/data/static/al_three_parts_date.css
@@ -31,3 +31,16 @@
 .al_three_parts_date .col > * {
   width: 100%;
 }
+
+/* Keeps the legend off of the page but still accessible to screen readers.
+ * Necessary because legends don't display correctly / the same as labels.
+ */
+legend.da-form-label:not(:focus):not(:active) {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0); 
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  white-space: nowrap; 
+}


### PR DESCRIPTION
Uses `fieldset` and `legend`, replacing docassemble's given `div`. Keeps the `label` as the visual element, as `legend` has display issues on Safari [^1].

Tested on Chrome and Safari on Mac, and in Firefox (which uses Safari's engine) on iPhone. Doesn't really improve the situation on iPhone, but that is expected, as group support on iPhone is poor [^1].

Fixes #164.

[^1]: https://adrianroselli.com/2022/07/use-legend-and-fieldset.html