### PR TITLE
Catch KeyError when removing evacuation day

### DIFF
--- a/docassemble/ALToolbox/business_days.py
+++ b/docassemble/ALToolbox/business_days.py
@@ -81,8 +81,12 @@ def standard_holidays(
     )
 
     # 2. Remove known obsolete holidays
-    if country == "US" and subdiv == "MA":
-        countr_holidays.pop_named("Evacuation Day")
+    try:
+        if country == "US" and subdiv == "MA":
+            countr_holidays.pop_named("Evacuation Day")
+    except KeyError:
+        # Starting with v0.94, holidays has removed Evacuation Day and throws an error. Can ignore it.
+        pass
 
     # 3. Remove user specified holidays
     if remove_holidays:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ ignore_missing_imports = true
 
 [dependency-groups]
 dev = [
-    "docassemble.base>=1.4",
-    "docassemble.webapp",
+    "docassemble.base>=1.8.0",
+    "docassemble.webapp>=1.8.0",
     "holidays>=0.13",
     "pandas>=1.4.2",
     "pandas-stubs",


### PR DESCRIPTION
Starting with v0.94 of the holiday's package, Evacuation day is no longer a thing and that pop call will throw an error.

Catches and ignores the error (folks could be using older versions of  `holidays`, so can't remove the call entirely).

Fixes current test failure on main.

https://github.com/vacanza/holidays/pull/3338