### PR TITLE
Don't break on docassemble 1.9.8

### DIFF
--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -1,14 +1,16 @@
-from docassemble.webapp.jsonstore import (
-    read_answer_json,
-    write_answer_json,
-    JsonStorage,
-    JsonDb,
-)
 from docassemble.base.generate_key import random_alphanumeric
 from docassemble.base.functions import get_current_info
-from docassemble.base.util import variables_snapshot_connection, user_info, DADict
-import random
+from docassemble.base.util import DADict
 from typing import Dict, List, Any, Optional
+from docassemble.webapp.jsonstore import JsonStorage
+
+try:
+    from docassemble.webapp.jsonstore import JsonDb
+except ImportError:
+    from docassemble.webapp.jsonstore import db
+
+    JsonDb = db.session
+
 
 __all__ = ["save_input_data"]
 


### PR DESCRIPTION
1.9.8 removed / changed how the jsonstore stuff works, which breaks the imports of `save_input_data` (even though it's not even used?? idk)

Tested on 1.9.8 and on older versions (1.9.2).