### PR TITLE
Change markitdown dependency to only PDF extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     'pandas>=2.0.3',
     'tiktoken>=0.8.0',
     'openai>=1.99.1',
-    'markitdown[all]>=0.1.3'
+    'markitdown[pdf]>=0.1.3'
 ]
 license="MIT"
 license-files = [


### PR DESCRIPTION
* only the PDF extra is used (https://github.com/SuffolkLITLab/docassemble-ALToolbox/blob/11c28b31d3cb00111e947c75945a4c72de416aca/docassemble/ALToolbox/llms.py#L761-L764 is the only place markitdown is used)
* the `all` dependency needs `youtube-transcription-api`, which is not available on python 3.14, which is used by docassemble 1.9.10 and above. Additionally, pip on docassemble will refuse to install any packages that have dependency conflicts.