### PR TITLE
Switch copy button to use normal text instead of a text input field

### DIFF
--- a/docassemble/ALToolbox/copy_button.py
+++ b/docassemble/ALToolbox/copy_button.py
@@ -1,3 +1,5 @@
+from html import escape
+
 from docassemble.base.functions import word
 
 __all__ = ["copy_button_html"]
@@ -19,15 +21,15 @@ def copy_button_html(
     Return the HTML for a button that will let a user copy the given text.
 
     Creates a copy-to-clipboard button with customizable styling and tooltip text.
-    The button can be configured to display as a simple input field or as a styled
-    template block suitable for displaying longer content.
+    The button can be configured to display as plain text or as a styled template
+    block suitable for displaying longer content.
 
     To use, include `docassemble.ALToolbox:copy_button.yml` in your DA interview.
 
     Args:
         text_to_copy (str): Text you want the user to be able to copy to clipboard.
         text_before (str, optional): The prompt that will appear to the left of the
-            HTML input. Defaults to "".
+            displayed text. Defaults to "".
         label (str, optional): The label text displayed on the copy button.
             Defaults to "Copy".
         tooltip_inert_text (str, optional): Tooltip text shown when hovering over
@@ -35,8 +37,8 @@ def copy_button_html(
         tooltip_copied_text (str, optional): Tooltip text shown when hovering over
             the button after the text is placed on the clipboard. Defaults to "Copied!".
         copy_template_block (bool, optional): If True, displays the content in a
-            textarea with template block styling. If False, uses a simple input field.
-            Defaults to False.
+            textarea with template block styling. If False, uses a simple inline text
+            container. Defaults to False.
         scroll_class (str, optional): CSS class for scroll behavior when using
             template block mode. Defaults to "".
         style_class (str, optional): Additional CSS classes for styling the container.
@@ -64,9 +66,9 @@ def copy_button_html(
     if copy_template_block:
         button_str += f'<textarea readonly class="card card-body {style_class} bg-light pb-1 al_copy_value {scroll_class}" {adjust_height}>{ text_to_copy }</textarea>\n'
 
-    # Add input tag if copy_template_block is False
+    # Add inline text container if copy_template_block is False
     else:
-        button_str += f'<input readonly class="al_copy_value" type="text" value="{ text_to_copy }">\n'
+        button_str += f'<span class="al_copy_value al_copy_value_text">{escape(text_to_copy)}</span>\n'
 
     # Add the copy button
     if copy_template_block:

--- a/docassemble/ALToolbox/data/questions/copy_button_demo.yml
+++ b/docassemble/ALToolbox/data/questions/copy_button_demo.yml
@@ -15,7 +15,7 @@ id: copy button demo
 question: |
   Button to copy text
 subquestion: |
-  This demo calls the **copy_button_html()** function to add a copy button to any text you specified. The text is displayed as a readonly **text input field**.
+  This demo calls the **copy_button_html()** function to add a copy button to any text you specified. The text is displayed as non-editable inline text styled to match a form control.
   
   This function is intended to provide a convenient way for mobile users to copy that text.  
   

--- a/docassemble/ALToolbox/data/static/copy_button.css
+++ b/docassemble/ALToolbox/data/static/copy_button.css
@@ -3,6 +3,20 @@
   vertical-align: bottom;
 }
 
+.al_copy_value_text {
+  display: inline-block;
+  width: 100%;
+  min-height: calc(1.5em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  color: #495057;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+}
+
 .al_visible_text {
   max-width: 100%;
   overflow-x: scroll;

--- a/docassemble/ALToolbox/data/static/copy_button.js
+++ b/docassemble/ALToolbox/data/static/copy_button.js
@@ -2,12 +2,35 @@ $(document).on('daPageLoad', function () {
   try {
     var copy_nodes = document.getElementsByClassName('al_copy');
 
+    function copyText( text ) {
+      if ( navigator.clipboard && navigator.clipboard.writeText ) {
+        return navigator.clipboard.writeText( text );
+      }
+
+      return new Promise(function( resolve, reject ) {
+        try {
+          var temp_input = document.createElement('textarea');
+          temp_input.value = text;
+          temp_input.setAttribute('readonly', '');
+          temp_input.style.position = 'absolute';
+          temp_input.style.left = '-9999px';
+          document.body.appendChild( temp_input );
+          temp_input.select();
+          document.execCommand('copy');
+          document.body.removeChild( temp_input );
+          resolve();
+        } catch ( error ) {
+          reject( error );
+        }
+      });
+    }
+
     for ( var node_i = 0; node_i < copy_nodes.length; node_i++ ) {
       add_copy_event_listeners( $(copy_nodes[ node_i ]) );
     }
 
     function add_copy_event_listeners( $node ) {
-      var input = $node.find('.al_copy_value')[0];
+      var copy_value = $node.find('.al_copy_value')[0];
       var $button = $node.find('.al_copy_button').eq(0);
       var $tooltip_inert = $node.find('.al_tooltip_inert').eq(0);
       var $tooltip_active = $node.find('.al_tooltip_active').eq(0);
@@ -25,13 +48,15 @@ $(document).on('daPageLoad', function () {
 
       $button.on( 'click', function ( event ) {
         try {
-          input.focus();
-          input.select();
-          document.execCommand("copy");
+          var text_to_copy = copy_value.value || copy_value.textContent || '';
 
-          $tooltip_inert.hide()
-          $tooltip_active.show()
-          input.blur();
+          copyText( text_to_copy ).then(function() {
+            $tooltip_inert.hide()
+            $tooltip_active.show()
+          }).catch(function( error ) {
+            console.warn( 'Error in AL copy button click' );
+            console.warn( error );
+          });
 
         } catch ( error ) {
           console.warn( 'Error in AL copy button click' );


### PR DESCRIPTION
Fix #346 

Makes it look pretty much exactly the same as before, except a slight difference on long/scrollable inputs:

<img width="825" height="921" alt="image" src="https://github.com/user-attachments/assets/306cb2ce-3d59-4959-8cff-2364c5de9c51" />


1. Converts into a `span` element
2. This should now be accessible to  a screen reader