### PR TITLE
Change conversion method to convert_local for PDFs

### DIFF
--- a/docassemble/ALToolbox/llms.py
+++ b/docassemble/ALToolbox/llms.py
@@ -761,7 +761,7 @@ def extract_fields_from_file(
     if not the_file.mimetype == "application/pdf" or not process_pdfs_with_ai:
         md = MarkItDown()
         try:
-            conversion_result = md.convert(the_file.path())
+            conversion_result = md.convert_local(the_file.path())
         except Exception as e:
             log(f"Error converting file {the_file.path()}: {e}")
             return {}


### PR DESCRIPTION
Following the advice of https://github.com/microsoft/markitdown/commit/a51f725d7ff4cdfe3bb6ad2ce2c04d98bf5f1f00, restrict the **default** conversion function to be the local version, and not the more general one.