### PR TITLE
[codex] Make times per year lookup robust

### DIFF
--- a/docassemble/ALToolbox/al_income.py
+++ b/docassemble/ALToolbox/al_income.py
@@ -113,7 +113,9 @@ def times_per_year(
     try:
         for row in times_per_year_list:
             if float(times_per_year) == float(row[0]):
-                return row[1].lower()
+                return str(row[1]).lower()
+            if float(times_per_year) == float(row[1]):
+                return str(row[0]).lower()
         return (
             docassemble.base.functions.nice_number(int(times_per_year), capitalize=True)
             + " "


### PR DESCRIPTION
## Summary

Makes `times_per_year()` tolerate cadence rows in either `[frequency, label]` or `[label, frequency]` order and return a string label consistently.

## Why

The integrated fee waiver path exposed a row-order mismatch that could return an integer to template code expecting a label.

## Validation

Locally deployed with the integrated MATC 1A divorce package set in the docassemble Docker container and ran the API driver end to end to the final download screen.