### PR TITLE
Fix JsonStorage imports for docassemble 1.10

### DIFF
--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -12,11 +12,11 @@ except ImportError:
     from docassemble.webapp.jsonstore import JsonStorage
 
     try:
-        from docassemble.webapp.jsonstore import JsonDb
+        from docassemble.webapp.jsonstore import JsonDb  # type: ignore[no-redef]
     except ImportError:
         from docassemble.webapp.jsonstore import db
 
-        JsonDb = db.session
+        JsonDb = db.session  # type: ignore[no-redef]
 
 
 __all__ = ["save_input_data"]

--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -2,14 +2,10 @@ from docassemble.base.generate_key import random_alphanumeric
 from docassemble.base.functions import get_current_info
 from docassemble.base.util import DADict
 from typing import Dict, List, Any, Optional
-from docassemble.webapp.jsonstore import JsonStorage
+from docassemble.webapp.extensions import db
+from docassemble.webapp.jsonstorage.helpers import JsonStorage
 
-try:
-    from docassemble.webapp.jsonstore import JsonDb
-except ImportError:
-    from docassemble.webapp.jsonstore import db
-
-    JsonDb = db.session
+JsonDb = db.session
 
 
 __all__ = ["save_input_data"]

--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -2,10 +2,21 @@ from docassemble.base.generate_key import random_alphanumeric
 from docassemble.base.functions import get_current_info
 from docassemble.base.util import DADict
 from typing import Dict, List, Any, Optional
-from docassemble.webapp.extensions import db
-from docassemble.webapp.jsonstorage.helpers import JsonStorage
 
-JsonDb = db.session
+try:
+    from docassemble.webapp.jsonstorage.helpers import JsonStorage
+    from docassemble.webapp.extensions import db
+
+    JsonDb = db.session
+except ImportError:
+    from docassemble.webapp.jsonstore import JsonStorage
+
+    try:
+        from docassemble.webapp.jsonstore import JsonDb
+    except ImportError:
+        from docassemble.webapp.jsonstore import db
+
+        JsonDb = db.session
 
 
 __all__ = ["save_input_data"]


### PR DESCRIPTION
## Summary

Fixes the removed `docassemble.webapp.jsonstore` private import for docassemble 1.10 while keeping the old import path as a fallback for older docassemble versions.

The compatibility order is:

1. Try the new docassemble 1.10 locations:
   - `docassemble.webapp.jsonstorage.helpers.JsonStorage`
   - `docassemble.webapp.extensions.db.session`
2. Fall back to the pre-1.10 `docassemble.webapp.jsonstore` path.

Fixes #352.

## Testing

Not run here; this should be smoke-tested in both environments:

```bash
python - <<'PY'
import docassemble.ALToolbox.save_input_data
PY
```

A fuller test should call `save_input_data()` inside a docassemble app/request context and confirm the row is written.