### PR TITLE
First pass at translation endpoint/js hook, addressing #356

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ docassemble.ALToolbox.egg-info/**
 coverage_html
 .env
 dist/**
+
+uv.lock

--- a/README.md
+++ b/README.md
@@ -15,6 +15,88 @@ If you want to add a small function to this project, consider adding it to the e
 Read the [documentation for the functions and components](https://assemblyline.suffolklitlab.org/docs/components/ALToolbox/overview) to learn
 how to use these components in your own [Docassemble](https://github.com/jhpyle/docassemble) projects.
 
+## Translating strings inside JavaScript
+
+Docassemble translates anything that reaches Python through `word()`, but JavaScript
+running in the browser has no way to reach that catalog, so strings in custom datatypes
+and small widgets tend to stay hardcoded in English.
+
+ALToolbox adds an endpoint, `/al_translations.json?lang=es`, that returns the `word()`
+catalog for a language, and a script that puts it behind `_()`:
+
+```yaml
+include:
+  - docassemble.ALToolbox:translation_strings.yml
+```
+
+Then, in your JavaScript:
+
+```js
+_("Copied!")                                  // "¡Copiado!"
+_("You have entered %d characters.", count)   // "Ha escrito 42 caracteres."
+_("%1$s of %2$s", done, total)                // positional, so a translation can reorder
+_("100%% sure")                               // "%%" is a literal percent sign
+```
+
+`alTranslate()` is the same function under a less collision-prone name. `_` is only
+assigned if nothing else has claimed it, so an interview that loads lodash or underscore
+keeps its own `_`.
+
+### Adding translations
+
+Write a word translation file and list it under `words:` in your server configuration —
+the same mechanism docassemble already uses for `word()`:
+
+```yaml
+# docassemble/yourpackage/data/sources/yourpackage_words.yml
+es:
+  Copied!: ¡Copiado!
+  You have entered %d characters.: Ha escrito %d caracteres.
+```
+
+```yaml
+# in the docassemble configuration
+words:
+  - docassemble.ALToolbox:data/sources/altoolbox_words.yml
+  - docassemble.yourpackage:data/sources/yourpackage_words.yml
+```
+
+For translations that come from somewhere other than a file, `add_translations()` adds
+them to the same catalog at runtime:
+
+```yaml
+code: |
+  add_translations("es", {"Copied!": "¡Copiado!"})
+```
+
+Lookups try an exact match first, then one that ignores surrounding whitespace,
+capitalization and trailing punctuation, restoring the source string's capitalization and
+punctuation on the way out. So a catalog entry for `copied` will still translate
+`_("Copied!")`.
+
+### What to expect
+
+The catalog is fetched once and kept in `localStorage`, keyed by language, so `_()`
+resolves synchronously on every page load after the first. On the very first load of a
+language the catalog is still in flight and `_()` returns the English source; listen for
+the `alTranslationsLoaded` event on `window` if you need to redraw when it arrives.
+
+Docassemble loads every script at the end of the body, so `_` exists from `daPageLoad`
+onward — which is where interview JavaScript normally does its work anyway. An inline
+`<script>` in a `subquestion` runs *before* that, so wrap it:
+
+```js
+document.addEventListener("DOMContentLoaded", function () {
+  document.getElementById("greeting").textContent = _("Hello");
+});
+```
+
+The endpoint is unauthenticated and identical for every user of a language — it exposes
+nothing but the server's own interface vocabulary. `translation_strings.translate()` is
+the server-side twin of `_()`, for when Python and JavaScript need to agree.
+
+Run `translation_strings_demo.yml` to see it working.
+
 ## Suffolk LIT Lab Document Assembly Line
 
 <img src="https://user-images.githubusercontent.com/7645641/142245862-c2eb02ab-3090-4e97-9653-bb700bf4c54d.png" alt="drawing of people working together on a website UI" width="300" style="align: center;"/>

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ document.addEventListener("DOMContentLoaded", function () {
 ```
 
 The endpoint is unauthenticated and identical for every user of a language — it exposes
-nothing but the server's own interface vocabulary. `translation_strings.translate()` is
-the server-side twin of `_()`, for when Python and JavaScript need to agree.
+the server's configured `word()` catalog for that language (which may include arbitrary
+phrases from installed packages). `translation_strings.translate()` is
 
 Run `translation_strings_demo.yml` to see it working.
 

--- a/docassemble/ALToolbox/data/questions/TextCounter.yml
+++ b/docassemble/ALToolbox/data/questions/TextCounter.yml
@@ -1,8 +1,11 @@
 metadata:
   title: ALToolbox - Text fields with a character counter
 ---
+include:
+  - translation_strings.yml
+---
 features:
-  javascript: TextCounter.js    
+  javascript: TextCounter.js
 ---
 id: block_at_line_7
 question: |

--- a/docassemble/ALToolbox/data/questions/altoolbox_overview.yml
+++ b/docassemble/ALToolbox/data/questions/altoolbox_overview.yml
@@ -68,7 +68,8 @@ code: |
     "output_checkbox_demo": ['Generate a conditional checkbox output for docx templates', 'misc.py'],
     "save_input_data_demo": ['Save input for data reporting', 'save_input_data.py'],
     "Shorten a url": ['Shorten a long url for neater display on the screen', 'misc.py'],
-    "TextCounter": ['Text input with a counter', 'TextCounter.js'], 
+    "TextCounter": ['Text input with a counter', 'TextCounter.js'],
+    "translation_strings_demo": ['Translate strings inside JavaScript with _()', 'translation_strings.yml'],
     "ThreePartsDate": ['Date input with month, day, year as separate parts', 'ThreePartsDate.py'],
   }
   add_records(samples_list, labels)

--- a/docassemble/ALToolbox/data/questions/translation_strings.yml
+++ b/docassemble/ALToolbox/data/questions/translation_strings.yml
@@ -1,0 +1,6 @@
+features:
+  javascript:
+    - al_translate.js
+---
+modules:
+  - .translation_strings

--- a/docassemble/ALToolbox/data/questions/translation_strings_demo.yml
+++ b/docassemble/ALToolbox/data/questions/translation_strings_demo.yml
@@ -1,0 +1,89 @@
+---
+metadata:
+  title: ALToolbox - Translate strings inside JavaScript
+  short title: JavaScript translation
+---
+include:
+  - translation_strings.yml
+---
+mandatory: True
+code: |
+  register_demo_words
+  chosen_language
+  set_language(chosen_language)
+  translation_demo
+---
+# Normally you would ship a word translation file and list it under `words:` in
+# the server configuration. This demo adds the same translations at runtime so
+# that it runs anywhere without a configuration change.
+code: |
+  add_translations(
+    "es",
+    {
+      "Copied!": "¡Copiado!",
+      "Thank you for your feedback.": "Gracias por sus comentarios.",
+      "You have entered %d characters.": "Ha escrito %d caracteres.",
+    },
+  )
+  register_demo_words = True
+---
+id: choose language
+question: |
+  Translating strings inside JavaScript
+subquestion: |
+  ALToolbox serves docassemble's `word()` catalog to the browser, so JavaScript
+  can call `_("Copied!")` and get the phrase in the user's language.
+
+  Pick a language and the next screen will show the same JavaScript strings
+  translated.
+fields:
+  - Language: chosen_language
+    datatype: radio
+    choices:
+      - English: en
+      - Spanish (español): es
+---
+id: translation demo
+event: translation_demo
+question: |
+  The same strings, from Python and from JavaScript
+subquestion: |
+  The page language is **${ chosen_language }**.
+
+  Python called `word("Copied!")` and got **${ word("Copied!") }**.
+
+  Below, JavaScript called `_()` for the same strings. The two should agree.
+
+  <ul id="al-translation-demo"></ul>
+
+  <script>
+    (function () {
+      function render() {
+        document.getElementById("al-translation-demo").innerHTML = [
+          _("Copied!"),
+          _("Thank you for your feedback."),
+          _("You have entered %d characters.", 42),
+        ]
+          .map(function (line) { return "<li>" + line + "</li>"; })
+          .join("");
+      }
+      function start() {
+        render();
+        // The first visit to a language fetches the catalog in the background,
+        // so redraw once it lands.
+        window.addEventListener("alTranslationsLoaded", render);
+      }
+      // Docassemble puts every script at the end of the body, so an inline
+      // script like this one runs before _() exists. Wait for the parser.
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+      } else {
+        start();
+      }
+    })();
+  </script>
+
+  You can see the raw catalog that the browser fetched at
+  [al_translations.json?lang=${ chosen_language }](${ url_of("root") }al_translations.json?lang=${ chosen_language }).
+buttons:
+  - Start over: restart

--- a/docassemble/ALToolbox/data/sources/altoolbox_words.yml
+++ b/docassemble/ALToolbox/data/sources/altoolbox_words.yml
@@ -1,0 +1,12 @@
+# Word translations for the strings ALToolbox's own JavaScript passes to _().
+# To use this file, add it to your server configuration:
+#
+#   words:
+#     - docassemble.ALToolbox:data/sources/altoolbox_words.yml
+#
+# The same format works for your own strings. Copy this file into your package's
+# data/sources directory, add your languages and phrases, and list it under
+# `words:` alongside this one.
+es:
+  You have entered %d character.: Ha escrito %d carácter.
+  You have entered %d characters.: Ha escrito %d caracteres.

--- a/docassemble/ALToolbox/data/static/TextCounter.js
+++ b/docassemble/ALToolbox/data/static/TextCounter.js
@@ -27,9 +27,9 @@ $(document).on('daPageLoad', function(){
 	  function updateCount() {			
       var count = $(elm).val().length;   
       if (count == 1) {
-        countMsg.text("You have entered " + count + " character.");	                
+        countMsg.text(_("You have entered %d character.", count));
       } else {
-        countMsg.text("You have entered " + count + " characters.");
+        countMsg.text(_("You have entered %d characters.", count));
       }
     }         
     $(elm).on('keyup keydown', updateCount);  

--- a/docassemble/ALToolbox/data/static/al_translate.js
+++ b/docassemble/ALToolbox/data/static/al_translate.js
@@ -1,0 +1,242 @@
+/* al_translate.js -- translate strings inside JavaScript.
+ *
+ *   _("Copied!")                               -> "¡Copiado!"
+ *   _("You have entered %d characters.", 42)   -> "Has escrito 42 caracteres."
+ *   _("%1$s of %2$s", 3, 10)                   -> positional, so a translation
+ *                                                 can reorder the arguments
+ *
+ * Translations come from docassemble's word() catalog, fetched once from
+ * /al_translations.json and cached in localStorage so that later page loads
+ * translate synchronously -- which matters because custom datatypes call _()
+ * while they build their markup.
+ *
+ * On the very first page load of a language the cache is cold and _() returns
+ * the English source. Listen for the "alTranslationsLoaded" event on window if
+ * you need to redraw when the catalog arrives.
+ */
+
+(function () {
+  "use strict";
+
+  var CACHE_PREFIX = "alTranslations/";
+  var CACHE_MAX_AGE_MS = 5 * 60 * 1000;
+
+  // Captured now because document.currentScript is null once we are async.
+  var scriptSrc = document.currentScript ? document.currentScript.src : "";
+
+  function catalogUrl(language) {
+    if (window.alTranslationsUrl) {
+      return window.alTranslationsUrl + "?lang=" + encodeURIComponent(language);
+    }
+    // This file is served from <root>/packagestatic/docassemble.ALToolbox/...,
+    // so stripping that suffix gives us the docassemble root, which is not
+    // always "/".
+    var root = scriptSrc.replace(/packagestatic\/.*$/, "");
+    return root + "al_translations.json?lang=" + encodeURIComponent(language);
+  }
+
+  function currentLanguage() {
+    return (
+      window.alTranslationsLang ||
+      document.documentElement.getAttribute("lang") ||
+      "en"
+    );
+  }
+
+  /* --- matching ---------------------------------------------------------- */
+
+  var TRAILING_PUNCTUATION = ".:!?";
+
+  // Keep in step with _normalize() in translation_strings.py.
+  function normalize(text) {
+    var collapsed = text.replace(/\s+/g, " ").trim();
+    while (
+      collapsed.length &&
+      TRAILING_PUNCTUATION.indexOf(collapsed.charAt(collapsed.length - 1)) !== -1
+    ) {
+      collapsed = collapsed.slice(0, -1);
+    }
+    return collapsed.toLowerCase();
+  }
+
+  // Keep in step with _match_shape() in translation_strings.py.
+  function matchShape(source, translated) {
+    var strippedSource = source.trim();
+    var result = translated.trim();
+    if (!result) {
+      return source;
+    }
+    var trailing = strippedSource.match(/[.:!?]+$/);
+    if (
+      trailing &&
+      TRAILING_PUNCTUATION.indexOf(result.charAt(result.length - 1)) === -1
+    ) {
+      result += trailing[0];
+    }
+    var firstSource = strippedSource.charAt(0);
+    var firstResult = result.charAt(0);
+    if (
+      firstSource === firstSource.toUpperCase() &&
+      firstSource !== firstSource.toLowerCase() &&
+      firstResult === firstResult.toLowerCase() &&
+      firstResult !== firstResult.toUpperCase()
+    ) {
+      result = firstResult.toUpperCase() + result.slice(1);
+    }
+    return result;
+  }
+
+  var words = {};
+  var normalizedWords = {};
+
+  function setWords(newWords) {
+    words = newWords || {};
+    normalizedWords = {};
+    Object.keys(words).forEach(function (source) {
+      // An exact match always wins, so only the first normalized spelling of a
+      // source string gets to claim the fuzzy slot.
+      var key = normalize(source);
+      if (!Object.prototype.hasOwnProperty.call(normalizedWords, key)) {
+        normalizedWords[key] = words[source];
+      }
+    });
+  }
+
+  function lookup(text) {
+    if (Object.prototype.hasOwnProperty.call(words, text)) {
+      return words[text];
+    }
+    var key = normalize(text);
+    if (Object.prototype.hasOwnProperty.call(normalizedWords, key)) {
+      return matchShape(text, normalizedWords[key]);
+    }
+    return text;
+  }
+
+  /* --- printf-style substitution ----------------------------------------- */
+
+  /* Supports %s, %d and positional %1$s, plus %% for a literal percent sign.
+   * Positional forms exist so a translator can put the arguments in whatever
+   * order their language needs. */
+  function format(template, args) {
+    var nextArg = 0;
+    return template.replace(
+      /%(?:(\d+)\$)?([sdi%])/g,
+      function (whole, position, kind) {
+        if (kind === "%") {
+          return "%";
+        }
+        var value = position ? args[parseInt(position, 10) - 1] : args[nextArg++];
+        if (value === undefined) {
+          return whole;
+        }
+        if (kind === "d" || kind === "i") {
+          var asNumber = parseInt(value, 10);
+          return isNaN(asNumber) ? String(value) : String(asNumber);
+        }
+        return String(value);
+      }
+    );
+  }
+
+  /* --- the public function ----------------------------------------------- */
+
+  function alTranslate(text) {
+    if (typeof text !== "string") {
+      return text;
+    }
+    // Always formatted, even with no arguments, so that "%%" reliably means a
+    // literal percent sign. A placeholder with no argument to fill it is left
+    // as written.
+    return format(lookup(text), Array.prototype.slice.call(arguments, 1));
+  }
+
+  window.alTranslate = alTranslate;
+  // Do not clobber lodash or underscore if an interview loaded one.
+  if (typeof window._ === "undefined") {
+    window._ = alTranslate;
+  }
+
+  /* --- cache and fetch ---------------------------------------------------- */
+
+  function readCache(language) {
+    try {
+      var raw = window.localStorage.getItem(CACHE_PREFIX + language);
+      return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      // Private browsing, a full quota, or hand-edited garbage. Not fatal.
+      return null;
+    }
+  }
+
+  function writeCache(language, catalogWords) {
+    try {
+      window.localStorage.setItem(
+        CACHE_PREFIX + language,
+        JSON.stringify({ fetched: Date.now(), words: catalogWords })
+      );
+    } catch (error) {
+      /* Nothing to do: we just refetch next time. */
+    }
+  }
+
+  function announce(language) {
+    window.dispatchEvent(
+      new CustomEvent("alTranslationsLoaded", { detail: { language: language } })
+    );
+  }
+
+  var activeLanguage = null;
+
+  function refresh(language) {
+    fetch(catalogUrl(language), { credentials: "same-origin" })
+      .then(function (response) {
+        return response.ok ? response.json() : null;
+      })
+      .then(function (catalog) {
+        if (!catalog || !catalog.words) {
+          return;
+        }
+        writeCache(language, catalog.words);
+        // The interview may have moved on to another language while this was
+        // in flight; the cache is still worth keeping, the words are not.
+        if (language === activeLanguage) {
+          setWords(catalog.words);
+          announce(language);
+        }
+      })
+      .catch(function () {
+        /* Offline or the endpoint is missing: keep the source strings. */
+      });
+  }
+
+  function load(language) {
+    activeLanguage = language;
+    var cached = readCache(language);
+    if (cached && cached.words) {
+      // Use the cache immediately so that _() works on this paint, then
+      // revalidate in the background if it is old enough to be worth a request.
+      setWords(cached.words);
+      if (!cached.fetched || Date.now() - cached.fetched > CACHE_MAX_AGE_MS) {
+        refresh(language);
+      }
+    } else {
+      // Better untranslated than translated into the language we just left.
+      setWords({});
+      refresh(language);
+    }
+  }
+
+  load(currentLanguage());
+
+  // Docassemble moves between screens over AJAX rather than reloading, and the
+  // interview language can change on the way, so re-check on every screen.
+  if (window.jQuery) {
+    window.jQuery(document).on("daPageLoad", function () {
+      var language = currentLanguage();
+      if (language !== activeLanguage) {
+        load(language);
+      }
+    });
+  }
+})();

--- a/docassemble/ALToolbox/test_translation_strings.py
+++ b/docassemble/ALToolbox/test_translation_strings.py
@@ -1,0 +1,189 @@
+# do not pre-load
+
+import os
+import re
+import unittest
+from unittest.mock import patch
+
+from .translation_strings import (
+    ALTOOLBOX_JS_STRINGS,
+    _catalog_response_body,
+    _match_shape,
+    _normalize,
+    add_translations,
+    translate,
+    translation_catalog,
+)
+
+FAKE_WORDS = {
+    "es": {
+        "Copied!": "¡Copiado!",
+        "you have entered %d characters.": "Ha escrito %d caracteres.",
+        "Cancel": None,
+    },
+    "es-MX": {
+        "Copied!": "¡Ya se copió!",
+    },
+}
+
+
+# Depending on how the tests are run, this package is importable under either
+# name, and each import is a distinct module object, so both have to be patched.
+MODULE_PATHS = (
+    "docassemble.ALToolbox.translation_strings",
+    "ALToolbox.translation_strings",
+)
+
+
+def with_fake_words(func):
+    """Swap in a small, predictable word_collection for the duration of a test."""
+    for module_path in MODULE_PATHS:
+        func = patch(f"{module_path}.word_collection", FAKE_WORDS)(func)
+    return func
+
+
+def with_language(language: str):
+    """Pretend the server's current language is `language`."""
+
+    def decorate(func):
+        for module_path in MODULE_PATHS:
+            func = patch(f"{module_path}.get_language", lambda: language)(func)
+        return func
+
+    return decorate
+
+
+class TestNormalize(unittest.TestCase):
+    def test_collapses_whitespace_punctuation_and_case(self) -> None:
+        self.assertEqual(_normalize("  Copied!  "), "copied")
+        self.assertEqual(_normalize("Are you\n  sure?"), "are you sure")
+        self.assertEqual(_normalize("Name:"), "name")
+
+    def test_leaves_interior_punctuation_alone(self) -> None:
+        self.assertEqual(_normalize("Yes. No."), "yes. no")
+
+
+class TestMatchShape(unittest.TestCase):
+    def test_restores_capitalization_and_trailing_punctuation(self) -> None:
+        self.assertEqual(_match_shape("Copied!", "copiado"), "Copiado!")
+
+    def test_does_not_double_up_punctuation(self) -> None:
+        self.assertEqual(_match_shape("Copied!", "¡Copiado!"), "¡Copiado!")
+
+    def test_leaves_a_lowercase_source_lowercase(self) -> None:
+        self.assertEqual(_match_shape("copied", "copiado"), "copiado")
+
+    def test_empty_translation_falls_back_to_the_source(self) -> None:
+        self.assertEqual(_match_shape("Copied!", "   "), "Copied!")
+
+
+class TestTranslationCatalog(unittest.TestCase):
+    @with_fake_words
+    def test_returns_the_catalog_for_a_language(self) -> None:
+        catalog = translation_catalog("es")
+        self.assertEqual(catalog["Copied!"], "¡Copiado!")
+
+    @with_fake_words
+    def test_drops_entries_with_no_translation(self) -> None:
+        self.assertNotIn("Cancel", translation_catalog("es"))
+
+    @with_fake_words
+    def test_a_regional_language_layers_on_top_of_its_base(self) -> None:
+        catalog = translation_catalog("es-MX")
+        # Overridden by the regional catalog...
+        self.assertEqual(catalog["Copied!"], "¡Ya se copió!")
+        # ...but the base language's other entries still come through.
+        self.assertIn("you have entered %d characters.", catalog)
+
+    @with_fake_words
+    def test_an_unknown_language_is_empty_rather_than_an_error(self) -> None:
+        self.assertEqual(translation_catalog("fr"), {})
+
+    @with_fake_words
+    @with_language("es")
+    def test_defaults_to_the_current_language(self) -> None:
+        self.assertEqual(translation_catalog()["Copied!"], "¡Copiado!")
+
+
+class TestTranslate(unittest.TestCase):
+    @with_fake_words
+    def test_exact_match(self) -> None:
+        self.assertEqual(translate("Copied!", "es"), "¡Copiado!")
+
+    @with_fake_words
+    def test_fuzzy_match_restores_the_shape_of_the_source(self) -> None:
+        # The catalog entry is lowercase and the source is not.
+        self.assertEqual(
+            translate("You have entered %d characters.", "es"),
+            "Ha escrito %d caracteres.",
+        )
+
+    @with_fake_words
+    def test_untranslated_strings_come_back_unchanged(self) -> None:
+        self.assertEqual(translate("Not in the catalog", "es"), "Not in the catalog")
+
+    @with_fake_words
+    def test_an_unknown_language_returns_the_source(self) -> None:
+        self.assertEqual(translate("Copied!", "fr"), "Copied!")
+
+
+class TestAddTranslations(unittest.TestCase):
+    def test_added_translations_are_visible_to_translate(self) -> None:
+        # Deliberately not patched: this has to reach docassemble's real,
+        # process-wide word_collection to be worth anything.
+        add_translations("zz", {"Copied!": "Xopied"})
+        try:
+            self.assertEqual(translate("Copied!", "zz"), "Xopied")
+        finally:
+            from docassemble.base.functions import word_collection as real_words
+
+            real_words.pop("zz", None)
+
+    def test_interviews_can_reach_it(self) -> None:
+        """`modules: - .translation_strings` only exposes names in __all__."""
+        from . import translation_strings
+
+        self.assertIn("add_translations", translation_strings.__all__)
+
+
+class TestCatalogResponseBody(unittest.TestCase):
+    @with_fake_words
+    def test_body_is_stable_json_with_the_language_and_words(self) -> None:
+        body = _catalog_response_body("es")
+        self.assertIn('"language": "es"', body)
+        self.assertIn("¡Copiado!", body)
+        # Sorted keys, so an unchanged catalog always produces the same ETag.
+        self.assertEqual(body, _catalog_response_body("es"))
+
+
+class TestAltoolboxJsStrings(unittest.TestCase):
+    """Keep the translator's checklist in step with the shipped JavaScript."""
+
+    def _static_path(self, name: str) -> str:
+        return os.path.join(os.path.dirname(__file__), "data", "static", name)
+
+    def test_every_string_passed_to_underscore_is_listed(self) -> None:
+        with open(self._static_path("TextCounter.js"), encoding="utf-8") as counter_js:
+            source = counter_js.read()
+        found = set(re.findall(r'\b_\(\s*"((?:[^"\\]|\\.)*)"', source))
+        self.assertTrue(found, "expected TextCounter.js to call _()")
+        self.assertTrue(
+            found.issubset(set(ALTOOLBOX_JS_STRINGS)),
+            f"missing from ALTOOLBOX_JS_STRINGS: {found - set(ALTOOLBOX_JS_STRINGS)}",
+        )
+
+    def test_the_shipped_word_file_covers_every_string(self) -> None:
+        import yaml  # type: ignore[import-untyped]
+
+        path = os.path.join(
+            os.path.dirname(__file__), "data", "sources", "altoolbox_words.yml"
+        )
+        with open(path, encoding="utf-8") as word_file:
+            words = yaml.safe_load(word_file)
+        for language, entries in words.items():
+            missing = set(ALTOOLBOX_JS_STRINGS) - set(entries)
+            self.assertFalse(missing, f"{language} is missing: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALToolbox/translation_strings.py
+++ b/docassemble/ALToolbox/translation_strings.py
@@ -184,8 +184,8 @@ try:
 
         Unauthenticated and session-independent on purpose: the response is the
         same for every user of a given language, which is what makes it worth
-        caching in the browser. It exposes nothing but the server's own
-        interface vocabulary.
+        caching in the browser. It serves the server's configured ``word()``
+        catalog for that language.
         """
         language = request.args.get("lang") or get_language()
         body = _catalog_response_body(language)

--- a/docassemble/ALToolbox/translation_strings.py
+++ b/docassemble/ALToolbox/translation_strings.py
@@ -1,0 +1,207 @@
+# pre-load
+"""Serve docassemble's ``word()`` translations to JavaScript.
+
+Docassemble can translate any string that reaches Python through ``word()``, but
+JavaScript running in the browser has no way to reach that catalog.  Custom
+datatypes, validation messages and small widgets therefore end up hardcoded in
+English.
+
+This module adds one unauthenticated endpoint, ``/al_translations.json``, that
+returns the ``word()`` catalog for a language code.  The companion
+``al_translate.js`` fetches it once, caches it in ``localStorage``, and exposes
+``_("Some string")`` to any JavaScript on the page.
+
+Authors add translations the ordinary docassemble way: a word translation file
+listed under ``words:`` in the server configuration.  See the README for the
+file format.
+
+The endpoint is registered with Flask using the "Building a custom page with
+Flask" recipe (https://docassemble.org/docs/recipes.html#flask%20page), which
+requires the ``# pre-load`` marker on the first line of this file.
+"""
+
+import json
+import re
+from typing import Dict, Iterator, Optional
+
+from docassemble.base.functions import (
+    get_language,
+    update_word_collection,
+    word_collection,
+)
+from docassemble.base.util import log
+
+__all__ = ["add_translations", "translate", "translation_catalog"]
+
+# Every string ALToolbox's own JavaScript passes to `_()`. Nothing reads this at
+# runtime; it is the checklist a translator needs, and a test keeps it honest by
+# grepping the shipped .js files.
+ALTOOLBOX_JS_STRINGS = [
+    "You have entered %d character.",
+    "You have entered %d characters.",
+]
+
+_TRAILING_PUNCTUATION = ".:!?"
+
+
+def _normalize(text: str) -> str:
+    """Reduce a string to the form used for fuzzy matching.
+
+    Collapses runs of whitespace, drops trailing punctuation, and lowercases,
+    so that "Copied!" and "copied" find the same translation.
+    """
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    return collapsed.rstrip(_TRAILING_PUNCTUATION).casefold()
+
+
+def _match_shape(source: str, translated: str) -> str:
+    """Give `translated` the capitalization and trailing punctuation of `source`.
+
+    Only used after a fuzzy match, so that translating "Copied!" against a
+    catalog entry for "copied" still comes back as "¡Copiado!" rather than
+    "copiado".
+    """
+    stripped_source = source.strip()
+    result = translated.strip()
+    if not result:
+        return source
+    trailing = re.search(r"[" + _TRAILING_PUNCTUATION + r"]+$", stripped_source)
+    if trailing and result[-1] not in _TRAILING_PUNCTUATION:
+        result += trailing.group(0)
+    if stripped_source[:1].isupper() and result[:1].islower():
+        result = result[0].upper() + result[1:]
+    return result
+
+
+def _language_candidates(language: str) -> Iterator[str]:
+    """Yield the languages to merge, least to most specific.
+
+    A page in "es-MX" should get the "es" catalog with any "es-MX" entries
+    layered on top.
+    """
+    base = re.split(r"[-_]", language)[0]
+    if base and base != language:
+        yield base
+    yield language
+
+
+def translation_catalog(language: Optional[str] = None) -> Dict[str, str]:
+    """Return the whole ``word()`` catalog for a language as ``{source: translation}``.
+
+    Args:
+        language: A language code such as ``"es"`` or ``"es-MX"``. Defaults to
+            the current language.
+
+    Returns:
+        A copy of the catalog. Unknown languages return an empty dictionary,
+        which is correct: every string then falls back to its source text.
+    """
+    if language is None:
+        language = get_language()
+    catalog: Dict[str, str] = {}
+    for candidate in _language_candidates(language):
+        entries = word_collection.get(candidate)
+        if isinstance(entries, dict):
+            catalog.update(
+                {
+                    str(source): str(translated)
+                    for source, translated in entries.items()
+                    if translated is not None
+                }
+            )
+    return catalog
+
+
+def translate(text: str, language: Optional[str] = None) -> str:
+    """Translate one string exactly the way ``al_translate.js`` does.
+
+    Tries an exact match first, then a match that ignores whitespace,
+    capitalization and trailing punctuation. Returns `text` unchanged when
+    there is no translation.
+
+    This is the server-side twin of the JavaScript ``_()``; use it when Python
+    and JavaScript need to agree on the same string.
+    """
+    catalog = translation_catalog(language)
+    if text in catalog:
+        return catalog[text]
+    normalized = _normalize(text)
+    for source, translated in catalog.items():
+        if _normalize(source) == normalized:
+            return _match_shape(text, translated)
+    return text
+
+
+def add_translations(language: str, translations: Dict[str, str]) -> None:
+    """Add entries to the ``word()`` catalog at runtime.
+
+    A word translation file listed under ``words:`` in the server configuration
+    is the better home for anything permanent: it loads once at startup and
+    every interview on the server sees it. Use this when the translations come
+    from somewhere else, or in a demo that has to run without a configuration
+    change.
+
+    Docassemble exposes ``update_word_collection()`` for this, but does not
+    include it in the names an interview can reach, so this is a thin wrapper
+    that ``include:``-ing ``translation_strings.yml`` makes available.
+
+    Args:
+        language: A language code such as ``"es"``.
+        translations: ``{source string: translation}``.
+
+    Note:
+        The catalog is process-wide and shared by every session, so pass the
+        same translations on every run rather than anything derived from one
+        user's answers.
+    """
+    update_word_collection(language, translations)
+
+
+def _catalog_response_body(language: str) -> str:
+    """Build the JSON body served by the endpoint."""
+    return json.dumps(
+        {
+            "language": language,
+            "words": translation_catalog(language),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+try:
+    try:
+        from docassemble.webapp.app_object import flaskapp as app  # 1.10 and later
+    except ImportError:
+        from docassemble.webapp.app_object import app  # type: ignore[no-redef]  # 1.9.x
+
+    from flask import Response, request
+    from werkzeug.wrappers import Response as BaseResponse
+
+    @app.route("/al_translations.json", methods=["GET"])
+    def al_translations_json() -> BaseResponse:
+        """Return the ``word()`` catalog for ``?lang=<code>`` as JSON.
+
+        Unauthenticated and session-independent on purpose: the response is the
+        same for every user of a given language, which is what makes it worth
+        caching in the browser. It exposes nothing but the server's own
+        interface vocabulary.
+        """
+        language = request.args.get("lang") or get_language()
+        body = _catalog_response_body(language)
+        response = Response(body, mimetype="application/json")
+        # A short max-age keeps a newly installed word file from taking hours to
+        # show up; the ETag means the usual revalidation costs a 304.
+        response.headers["Cache-Control"] = "public, max-age=300"
+        response.add_etag()
+        return response.make_conditional(request)
+
+except BaseException as error:  # pragma: no cover - depends on the environment
+    # BaseException, not Exception: outside a configured web server (in a test
+    # run, say) importing the Flask app calls sys.exit(). A server that cannot
+    # register the route should serve untranslated JavaScript; nothing here is
+    # worth taking the process down for.
+    log(
+        "ALToolbox: could not register /al_translations.json: "
+        f"{error.__class__.__name__}: {error}"
+    )

--- a/docassemble/ALToolbox/translation_strings.py
+++ b/docassemble/ALToolbox/translation_strings.py
@@ -173,7 +173,7 @@ try:
     try:
         from docassemble.webapp.app_object import flaskapp as app  # 1.10 and later
     except ImportError:
-        from docassemble.webapp.app_object import app  # type: ignore[no-redef]  # 1.9.x
+        from docassemble.webapp.app_object import app  # type: ignore[no-redef, attr-defined]  # 1.9.x
 
     from flask import Response, request
     from werkzeug.wrappers import Response as BaseResponse

--- a/docassemble/ALToolbox/translation_strings.py
+++ b/docassemble/ALToolbox/translation_strings.py
@@ -51,7 +51,7 @@ def _normalize(text: str) -> str:
     so that "Copied!" and "copied" find the same translation.
     """
     collapsed = re.sub(r"\s+", " ", text).strip()
-    return collapsed.rstrip(_TRAILING_PUNCTUATION).casefold()
+    return collapsed.rstrip(_TRAILING_PUNCTUATION).lower()
 
 
 def _match_shape(source: str, translated: str) -> str:


### PR DESCRIPTION
1. Publishes the `word()` catalog as an unauthenticated endpoint, with language filters, /al_translate.json?lang=es
2. JS side, if importing al_translate.js, can now use _("Some string %var") to translate various phrases in custom datatypes and the like
3. Won't clobber existing _ in the namespace; available as alTranslate as well.

~Note: mypy issues seem to be caused by a new release of mypy; I also fixed them separately in #358 but might move to a separate standalone PR instead~ [Fixed test failures both in `main` and in this branch]