### PR TITLE
Fix unit tests and typing against newer docassemble

### DIFF
--- a/docassemble/ALToolbox/business_days.py
+++ b/docassemble/ALToolbox/business_days.py
@@ -265,15 +265,16 @@ def is_business_day(
         is_business_uk = is_business_day("2023-12-26", country="UK")  # Boxing Day
         ```
     """
-    if not isinstance(date, DADateTime):
-        date = as_datetime(date)
-    if date.dow in [
+    date_to_check: DADateTime = (
+        date if isinstance(date, DADateTime) else as_datetime(date)
+    )
+    if date_to_check.dow in [
         6,
         7,
     ]:  # Docassemble codes Saturday and Sunday as 6 and 7 respectively
         return False
-    if date.format("yyyy-MM-dd") in standard_holidays(
-        year=date.year,
+    if date_to_check.format("yyyy-MM-dd") in standard_holidays(
+        year=date_to_check.year,
         country=country,
         subdiv=subdiv,
         add_holidays=add_holidays,
@@ -339,9 +340,10 @@ def get_next_business_day(
         # Will skip March 17th as it's now considered a holiday
         ```
     """
-    if not isinstance(start_date, DADateTime):
-        start_date = as_datetime(start_date)
-    date_to_check = start_date.plus(days=wait_n_days)
+    start: DADateTime = (
+        start_date if isinstance(start_date, DADateTime) else as_datetime(start_date)
+    )
+    date_to_check: DADateTime = start.plus(days=wait_n_days)
 
     while not is_business_day(
         date_to_check,
@@ -405,9 +407,9 @@ def get_date_after_n_business_days(
         # Will count 3 business days, skipping weekends and custom holiday
         ```
     """
-    if not isinstance(start_date, DADateTime):
-        start_date = as_datetime(start_date)
-    date_to_check = start_date
+    date_to_check: DADateTime = (
+        start_date if isinstance(start_date, DADateTime) else as_datetime(start_date)
+    )
 
     for _ in range(wait_n_days):
         date_to_check = date_to_check.plus(days=1)

--- a/docassemble/ALToolbox/conftest.py
+++ b/docassemble/ALToolbox/conftest.py
@@ -1,0 +1,83 @@
+"""Minimal docassemble runtime context for the python-only unit tests.
+
+As of docassemble 1.10, per-request state lives in a contextvar exposed as
+`docassemble.base.thread_context.this_thread`, and the defaults that back it
+(language, locale, timezone, ...) come from pluggy hooks that only
+`docassemble.webapp` registers when a server starts up. Under plain pytest
+neither exists, so library code that calls `get_locale()` or `as_datetime()`
+fails on `None`.
+
+These fixtures stand in for the server: they register the handful of default
+hooks the tests need and wrap each test in a fresh global context.
+"""
+
+import locale
+
+import pluggy
+import pytest
+
+from docassemble.base.plugin_manager import pm
+from docassemble.base.thread_context import empty_globals, global_context
+
+hookimpl = pluggy.HookimplMarker("docassemble")
+
+# The locale the tests assume unless one of them overrides it. The workflow
+# runs locale-gen for this and for ar_AE.UTF-8.
+TEST_LOCALE = "en_US.UTF-8"
+
+
+class DefaultsPlugin:
+    """Supplies the same defaults a docassemble server would with no config."""
+
+    @hookimpl
+    def get_default_language(self) -> str:
+        return "en"
+
+    @hookimpl
+    def get_default_dialect(self) -> str:
+        return "us"
+
+    @hookimpl
+    def get_default_locale(self) -> str:
+        return "en_US.utf8"
+
+    @hookimpl
+    def get_default_country(self) -> str:
+        return "US"
+
+    @hookimpl
+    def get_default_timezone(self) -> str:
+        return "America/New_York"
+
+    @hookimpl
+    def get_configuration(self) -> dict:
+        return {}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def docassemble_defaults():
+    plugin = DefaultsPlugin()
+    pm.register(plugin, name="altoolbox_test_defaults")
+    yield
+    pm.unregister(plugin)
+
+
+@pytest.fixture(autouse=True)
+def docassemble_context(docassemble_defaults):
+    """Give each test its own `this_thread`, so state can't leak between them."""
+    with global_context(empty_globals()):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def us_locale():
+    """Run every test under the US locale.
+
+    `frac_digits` drives currency rounding in al_income, so tests that expect
+    two decimal places need a locale that specifies them. Restoring afterwards
+    keeps the tests that deliberately switch locales from leaking.
+    """
+    previous = locale.setlocale(locale.LC_ALL)
+    locale.setlocale(locale.LC_ALL, TEST_LOCALE)
+    yield
+    locale.setlocale(locale.LC_ALL, previous)

--- a/docassemble/ALToolbox/llms.py
+++ b/docassemble/ALToolbox/llms.py
@@ -67,7 +67,7 @@ else:
 
 always_reserved_names = set(
     docassemble.base.util.__all__
-    + keyword.kwlist
+    + list(keyword.kwlist)
     + list(dir(__builtins__))
     + [
         "_attachment_email_address",

--- a/docassemble/ALToolbox/save_input_data.py
+++ b/docassemble/ALToolbox/save_input_data.py
@@ -9,12 +9,12 @@ try:
 
     JsonDb = db.session
 except ImportError:
-    from docassemble.webapp.jsonstore import JsonStorage
+    from docassemble.webapp.jsonstore import JsonStorage  # type: ignore[no-redef]
 
     try:
         from docassemble.webapp.jsonstore import JsonDb  # type: ignore[no-redef]
     except ImportError:
-        from docassemble.webapp.jsonstore import db
+        from docassemble.webapp.jsonstore import db  # type: ignore[no-redef]
 
         JsonDb = db.session  # type: ignore[no-redef]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "pandas>=1.4.2",
     "pandas-stubs",
     "mypy",
+    "pytest",
     "openai>=1.0",
     "tiktoken",
     "defusedxml",


### PR DESCRIPTION
Two unrelated breakages, both from docassemble moving forward.

Tests: as of docassemble 1.10, per-request state lives in a contextvar (`this_thread`) and its defaults come from pluggy hooks that only `docassemble.webapp` registers at server startup. Under plain pytest neither exists, so `get_locale()` and `as_datetime()` failed on `None`. Importing docassemble also no longer sets the process locale, which `test_al_income` relied on -- it only sets the locale itself under `__main__`, so currency rounding used `frac_digits` of 127.

Add a conftest.py that registers the defaults a bare server would use and wraps each test in a fresh global context and the US locale.

Typing: docassemble-base 1.10.6 ships py.typed, so imports that used to resolve to Any now carry real types, surfacing 8 mypy errors. `as_datetime` is still unannotated, so assigning its result back onto a `Union[str, DADateTime]` parameter no longer narrows -- use explicitly typed locals instead. `keyword.kwlist` is a `Sequence[str]`, not a list. The `jsonstore` fallback imports needed the same no-redef ignores their neighbors already had.

Verified green under both docassemble 1.10.5 (what CI resolves today) and 1.10.6.