### PR TITLE
Make display_template heading level configurable

### DIFF
--- a/docassemble/ALToolbox/display_template.py
+++ b/docassemble/ALToolbox/display_template.py
@@ -12,6 +12,7 @@ def display_template(
     copy=False,
     classname="bg-light",
     class_name=None,  # deprecated
+    h_level=2,
 ) -> str:
     """
     Display a template with optional scrolling, collapsing, and copy functionality.
@@ -33,6 +34,8 @@ def display_template(
             Defaults to "bg-light".
         class_name (str, optional): Deprecated parameter for CSS class name.
             Defaults to None.
+        h_level (int, optional): The HTML heading level for the template subject.
+            Must be between 1 and 6. Defaults to 2.
 
     Returns:
         HTML string containing the rendered template with the specified
@@ -45,6 +48,9 @@ def display_template(
     ```
     """
     # 1. Initialize
+    if not isinstance(h_level, int) or not 1 <= h_level <= 6:
+        raise ValueError("h_level must be an integer between 1 and 6")
+
     if scrollable:
         scroll_class = "scrollable-panel"
         adjust_height = ""
@@ -94,7 +100,7 @@ def display_template(
     subject_html = ""
     subject_span = '<span class="subject"></span>'
     if has_subject:
-        subject_html = f'<div class="panel-heading"><h3 class="subject" id="{subject_id}">{subject_content}</h3></div>'
+        subject_html = f'<div class="panel-heading"><h{h_level} class="subject" id="{subject_id}">{subject_content}</h{h_level}></div>'
         subject_span = (
             f'<span class="subject" id="{subject_id}">{subject_content}</span>'
         )

--- a/docassemble/ALToolbox/test_display_template.py
+++ b/docassemble/ALToolbox/test_display_template.py
@@ -1,0 +1,36 @@
+import unittest
+from types import SimpleNamespace
+
+from .display_template import display_template
+
+
+class TestDisplayTemplate(unittest.TestCase):
+    def setUp(self):
+        self.template = SimpleNamespace(
+            instanceName="test-template",
+            subject="Subject",
+            subject_as_html=lambda trim: "Subject",
+            content_as_html=lambda: "Content",
+        )
+
+    def test_subject_defaults_to_h2(self):
+        html = display_template(self.template)
+
+        self.assertIn('<h2 class="subject"', html)
+        self.assertNotIn("<h3", html)
+
+    def test_subject_heading_level_can_be_customized(self):
+        html = display_template(self.template, h_level=4)
+
+        self.assertIn('<h4 class="subject"', html)
+        self.assertNotIn("<h2", html)
+
+    def test_subject_heading_level_must_be_between_one_and_six(self):
+        for h_level in (0, 7, "2"):
+            with self.subTest(h_level=h_level):
+                with self.assertRaises(ValueError):
+                    display_template(self.template, h_level=h_level)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Change the default subject heading from `<h3>` to `<h2>`.
- Add an `h_level` parameter for heading levels 1 through 6.
- Add focused tests for the default, custom, and invalid levels.

## Validation

- Focused unittest: passed (3 tests)
- mypy: passed
- Black: passed
- Full unittest suite: 69 passed; 11 unrelated pre-existing failures in income precision and timezone-context tests.